### PR TITLE
CI-17: Allow `require` to be used.

### DIFF
--- a/projects/cr-lib/tsconfig.lib.json
+++ b/projects/cr-lib/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "target": "es2015",
     "declaration": true,
     "inlineSources": true,
-    "types": [],
+    "types": ["node"],
     "lib": [
       "dom",
       "es2018"

--- a/projects/player/tsconfig.json
+++ b/projects/player/tsconfig.json
@@ -14,6 +14,7 @@
     "typeRoots": [
       "node_modules/@types"
     ],
+    "types": ["node"],
     "lib": [
       "es2018",
       "dom"


### PR DESCRIPTION
- Adds "node" to the types array so I can "require" instead of import.