### PR TITLE
CI-20 Tidy up the Auth0 names

### DIFF
--- a/projects/cr-lib/src/lib/auth/auth0Config/auth0-variables.ts
+++ b/projects/cr-lib/src/lib/auth/auth0Config/auth0-variables.ts
@@ -12,11 +12,11 @@ interface AuthConfig {
 export const AUTH_CONFIG: AuthConfig = {
   /* This is publicly shareable. */
   clientID: {
-    social: 'ZztcBTDcglTr10lyuLoq8Zy57EW4HXTZ',
-    passwordless: 't6RcrSkjxxFfI0JCMsEifO8QJ72YBcDY'
+    social: 'LbrBEjWpXwzZ3x4EiMHV22dnenwVsXn4',
+    passwordless: '5Bvzw8AYEA4Hl3VARQ55t3wwINapre5Z'
   },
   domain: {
-    social: 'clueride-social.auth0.com',
-    passwordless: 'clueride.auth0.com'
+    social: 'clueride-shared.auth0.com',
+    passwordless: 'clueride-shared.auth0.com'
   },
 };

--- a/projects/player/package.json
+++ b/projects/player/package.json
@@ -83,7 +83,7 @@
       "cordova-plugin-customurlscheme": {
         "URL_SCHEME": "com.clueride.player",
         "ANDROID_SCHEME": "com.clueride.player",
-        "ANDROID_HOST": "clueride-social.auth0.com",
+        "ANDROID_HOST": "clueride-shared.auth0.com",
         "ANDROID_PATHPREFIX": "/cordova/com.clueride.player/callback"
       }
     },


### PR DESCRIPTION
- Moves to shared tenant.
- Adjusts the auth0 config to reflect single tenant with two new auth0-app
client IDs.