### PR TITLE
CI-27 Move MobiLoc to new Ionic 4 Auth

### DIFF
--- a/projects/locEdit/angular.json
+++ b/projects/locEdit/angular.json
@@ -12,7 +12,7 @@
       "schematics": {},
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:browser",
+          "builder": "@angular-builders/custom-webpack:browser",
           "options": {
             "outputPath": "www",
             "index": "src/index.html",
@@ -20,6 +20,9 @@
             "polyfills": "src/polyfills.ts",
             "preserveSymlinks": true,
             "tsConfig": "tsconfig.app.json",
+            "customWebpackConfig": {
+              "path": "../../webpack.config.js"
+            },
             "assets": [
               {
                 "glob": "**/*",
@@ -73,9 +76,12 @@
           }
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular-builders/custom-webpack:dev-server",
           "options": {
-            "browserTarget": "locEdit:build"
+            "browserTarget": "locEdit:build",
+            "customWebpackConfig": {
+              "path": "../../webpack.config.js"
+            }
           },
           "configurations": {
             "production": {

--- a/projects/locEdit/config.xml
+++ b/projects/locEdit/config.xml
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="io.ionic.starter" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
-    <name>MyApp</name>
-    <description>An awesome Ionic/Cordova app.</description>
-    <author email="hi@ionicframework.com" href="http://ionicframework.com/">Ionic Framework Team</author>
+<widget id="io.ionic.starter" version="0.0.1" xmlns="http://www.w3.org/ns/widgets">
+    <name>Ranger</name>
+    <description>Clue Ride Attraction Editing</description>
+    <author email="clueride@gmail.com" href="https://clueride.com/">Clue Ride</author>
     <content src="index.html" />
     <access origin="*" />
     <allow-intent href="http://*/*" />
@@ -13,6 +13,7 @@
     <allow-intent href="geo:*" />
     <preference name="ScrollEnabled" value="false" />
     <preference name="android-minSdkVersion" value="19" />
+    <preference name="AndroidLaunchMode" value="singleTask" />
     <preference name="BackupWebStorage" value="none" />
     <preference name="SplashMaintainAspectRatio" value="true" />
     <preference name="FadeSplashScreenDuration" value="300" />

--- a/projects/locEdit/package-lock.json
+++ b/projects/locEdit/package-lock.json
@@ -4,6 +4,44 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@angular-builders/custom-webpack": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@angular-builders/custom-webpack/-/custom-webpack-8.4.1.tgz",
+      "integrity": "sha512-FbBt4mFbAxETdYLb6tTX869pIpm8nMiCpT34jROejuqLtsljymdqXhSCEWogWlel8ULAYus6BNdzZyRLyAkfqQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.10",
+        "ts-node": "^8.5.2",
+        "webpack-merge": "^4.2.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+          "dev": true
+        },
+        "ts-node": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
+          "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
+          "dev": true,
+          "requires": {
+            "arg": "^4.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "source-map-support": "^0.5.6",
+            "yn": "^3.0.0"
+          }
+        },
+        "yn": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+          "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+          "dev": true
+        }
+      }
+    },
     "@angular-devkit/architect": {
       "version": "0.801.3",
       "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.801.3.tgz",
@@ -1240,6 +1278,21 @@
         "@types/cordova": "^0.0.34"
       }
     },
+    "@ionic-native/safari-view-controller": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@ionic-native/safari-view-controller/-/safari-view-controller-5.18.0.tgz",
+      "integrity": "sha512-prui2/iOrV1YKNNbdAhTKExz0fbGfxRP2NjjUvLh8/df4ftchZzJG1eZ7o4Rw0FYq24Q8tMN9DiaPcfPcMUdKw==",
+      "requires": {
+        "@types/cordova": "^0.0.34"
+      },
+      "dependencies": {
+        "@types/cordova": {
+          "version": "0.0.34",
+          "resolved": "https://registry.npmjs.org/@types/cordova/-/cordova-0.0.34.tgz",
+          "integrity": "sha1-6nrd907Ow9dimCegw54smt3HPQQ="
+        }
+      }
+    },
     "@ionic-native/splash-screen": {
       "version": "5.16.0",
       "resolved": "https://registry.npmjs.org/@ionic-native/splash-screen/-/splash-screen-5.16.0.tgz",
@@ -1819,6 +1872,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
+    },
+    "arg": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz",
+      "integrity": "sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==",
       "dev": true
     },
     "argparse": {
@@ -3200,6 +3259,11 @@
         }
       }
     },
+    "cordova-plugin-customurlscheme": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-customurlscheme/-/cordova-plugin-customurlscheme-5.0.0.tgz",
+      "integrity": "sha512-AuVlQyq88cCxGyoYvQyx2N6igLZ5aHxEqGch2vdu1EWvxHzsjj33VFgA3+tjzJUmYYgIN4QYTkyOVsLIMozIPg=="
+    },
     "cordova-plugin-device": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/cordova-plugin-device/-/cordova-plugin-device-2.0.2.tgz",
@@ -3217,6 +3281,11 @@
       "resolved": "https://registry.npmjs.org/cordova-plugin-ionic-webview/-/cordova-plugin-ionic-webview-4.1.3.tgz",
       "integrity": "sha512-hlrUF0kLjjEkZmpYlLJO0NnXmVjMmQ3MOZVXm1ytDihLPKHklYCOpCvjA5Wz3hJrPD1shFEsqi/SPnp873AsdQ==",
       "dev": true
+    },
+    "cordova-plugin-safariviewcontroller": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-safariviewcontroller/-/cordova-plugin-safariviewcontroller-1.6.0.tgz",
+      "integrity": "sha512-TSrVTTdIjCb1iK+FT0GSnfVhmEY5oRzB2yhlwSnxgwxhTrFHDnfTXrX4KKHWaszxGnMKNFuUFTv8K+fc0GNqEg=="
     },
     "cordova-plugin-splashscreen": {
       "version": "5.0.2",

--- a/projects/locEdit/package.json
+++ b/projects/locEdit/package.json
@@ -21,18 +21,22 @@
     "@angular/platform-browser-dynamic": "~8.1.2",
     "@angular/router": "~8.1.2",
     "@ionic-native/core": "^5.0.0",
+    "@ionic-native/safari-view-controller": "^5.18.0",
     "@ionic-native/splash-screen": "^5.0.0",
     "@ionic-native/status-bar": "^5.0.0",
     "@ionic/angular": "^4.7.1",
     "@ionic/pro": "2.0.4",
     "cordova-android": "8.1.0",
     "cordova-ios": "5.1.1",
+    "cordova-plugin-customurlscheme": "5.0.0",
+    "cordova-plugin-safariviewcontroller": "1.6.0",
     "core-js": "^2.5.4",
     "rxjs": "~6.5.1",
     "tslib": "^1.9.0",
     "zone.js": "~0.9.1"
   },
   "devDependencies": {
+    "@angular-builders/custom-webpack": "^8.4.1",
     "@angular-devkit/architect": "~0.801.2",
     "@angular-devkit/build-angular": "~0.801.2",
     "@angular-devkit/core": "~8.1.2",
@@ -71,7 +75,14 @@
       "cordova-plugin-device": {},
       "cordova-plugin-splashscreen": {},
       "cordova-plugin-ionic-webview": {},
-      "cordova-plugin-ionic-keyboard": {}
+      "cordova-plugin-ionic-keyboard": {},
+      "cordova-plugin-safariviewcontroller": {},
+      "cordova-plugin-customurlscheme": {
+        "URL_SCHEME": "com.clueride.ranger",
+        "ANDROID_SCHEME": "com.clueride.ranger",
+        "ANDROID_HOST": "clueride-shared.auth0.com",
+        "ANDROID_PATHPREFIX": "/cordova/com.clueride.ranger/callback"
+      }
     },
     "platforms": [
       "ios",

--- a/projects/locEdit/src/app/app.component.ts
+++ b/projects/locEdit/src/app/app.component.ts
@@ -1,9 +1,9 @@
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
+import {SplashScreen} from '@ionic-native/splash-screen/ngx';
+import {StatusBar} from '@ionic-native/status-bar/ngx';
 
-import { Platform } from '@ionic/angular';
-import { SplashScreen } from '@ionic-native/splash-screen/ngx';
-import { StatusBar } from '@ionic-native/status-bar/ngx';
-import {PlatformStateService} from 'cr-lib';
+import {Platform} from '@ionic/angular';
+import {AwaitRegistrationService, PlatformStateService} from 'cr-lib';
 
 @Component({
   selector: 'app-root',
@@ -27,6 +27,7 @@ export class AppComponent {
   constructor(
     private platform: Platform,
     private platformStateService: PlatformStateService,
+    private authClient: AwaitRegistrationService,
     private splashScreen: SplashScreen,
     private statusBar: StatusBar
   ) {
@@ -35,11 +36,20 @@ export class AppComponent {
 
   initializeApp() {
     this.platform.ready().then(() => {
+
       if (this.platformStateService.isNativeMode()) {
         /* Since this is a cordova native statusbar, only set style if not within a browser (local). */
         this.statusBar.styleDefault();
         this.splashScreen.hide();
       }
+
+      this.authClient.getRegistrationActiveObservable('com.clueride.ranger')
+        .subscribe(ready => {
+          if (ready) {
+            console.log('Registered');
+            // TODO: CI-25 Kick off the application loading.
+          }
+        });
     });
   }
 }

--- a/projects/locEdit/src/app/app.module.ts
+++ b/projects/locEdit/src/app/app.module.ts
@@ -1,14 +1,15 @@
 import {HttpClientModule} from '@angular/common/http';
-import { NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
-import { RouteReuseStrategy } from '@angular/router';
+import {NgModule} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+import {RouteReuseStrategy} from '@angular/router';
+import {SplashScreen} from '@ionic-native/splash-screen/ngx';
+import {StatusBar} from '@ionic-native/status-bar/ngx';
 
-import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
-import { SplashScreen } from '@ionic-native/splash-screen/ngx';
-import { StatusBar } from '@ionic-native/status-bar/ngx';
+import {IonicModule, IonicRouteStrategy} from '@ionic/angular';
+import {AuthModule} from 'cr-lib';
+import {AppRoutingModule} from './app-routing.module';
 
-import { AppComponent } from './app.component';
-import { AppRoutingModule } from './app-routing.module';
+import {AppComponent} from './app.component';
 
 @NgModule({
   declarations: [AppComponent],
@@ -17,6 +18,7 @@ import { AppRoutingModule } from './app-routing.module';
     BrowserModule,
     IonicModule.forRoot(),
     AppRoutingModule,
+    AuthModule,
     HttpClientModule
   ],
   providers: [

--- a/projects/player/src/app/app.component.ts
+++ b/projects/player/src/app/app.component.ts
@@ -1,10 +1,9 @@
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
+import {SplashScreen} from '@ionic-native/splash-screen/ngx';
+import {StatusBar} from '@ionic-native/status-bar/ngx';
 
-import { Platform } from '@ionic/angular';
-import { SplashScreen } from '@ionic-native/splash-screen/ngx';
-import { StatusBar } from '@ionic-native/status-bar/ngx';
-import {PlatformStateService} from 'cr-lib';
-import {AwaitRegistrationService} from 'cr-lib';
+import {Platform} from '@ionic/angular';
+import {AwaitRegistrationService, PlatformStateService} from 'cr-lib';
 
 @Component({
   selector: 'app-root',
@@ -49,7 +48,7 @@ export class AppComponent {
         .subscribe(ready => {
           if (ready) {
             console.log('Registered');
-            // TODO: Kick off the application loading.
+            // TODO: CI-25 Kick off the application loading.
           }
         });
     });


### PR DESCRIPTION
- Imports AuthModule.
- Adds invocation of Auth code.
- Renames application to `Ranger` (just because it is more fun).
- Adds supporting webpack changes to allow crypto polyfill.
- Adds supporting plugins for Auth0 3rd-party modules.

Much of the work was at the command-line to add/install the necessary
modules. This work was first performed against the 'player' app in CI-19.