### PR TITLE
CI-36 Patch up ion-fab for Ionic 4

### DIFF
--- a/projects/ranger/src/app/map/action/map-action.component.html
+++ b/projects/ranger/src/app/map/action/map-action.component.html
@@ -1,0 +1,31 @@
+<ion-fab horizontal="end" vertical="top">
+  <ion-fab-button size="small" (click)="settingsFabAction($event)">
+    <ion-icon name="settings"></ion-icon>
+  </ion-fab-button>
+  <ion-fab-list>
+
+    <div class="labeledFab">
+      <ion-label>Toggle Lat/Lon</ion-label>
+      <ion-fab-button size="small" (click)="settingsToggleLatLon($event)">
+        <ion-icon name="checkmark"></ion-icon>
+      </ion-fab-button>
+    </div>
+
+    <div class="labeledFab">
+      <ion-label>Toggle Auto-center</ion-label>
+      <ion-fab-button size="small" (click)="settingsToggleAutoCenter($event)">
+        <ion-icon name="locate"></ion-icon>
+      </ion-fab-button>
+    </div>
+
+    <div class="labeledFab">
+      <ion-label>Refresh Map</ion-label>
+      <ion-fab-button size="small" (click)="refreshMap($event)">
+        <ion-icon name="refresh"></ion-icon>
+      </ion-fab-button>
+    </div>
+
+  </ion-fab-list>
+</ion-fab>
+
+

--- a/projects/ranger/src/app/map/action/map-action.component.scss
+++ b/projects/ranger/src/app/map/action/map-action.component.scss
@@ -1,0 +1,16 @@
+
+.labeledFab {
+  overflow: visible;
+  position: relative;
+
+  ion-label {
+    position: absolute;
+    right: 50px;
+
+    color: white;
+    background-color: rgba(0,0,0,0.7);
+    line-height: 20px;
+    padding: 4px 8px;
+    border-radius: 4px;
+  }
+}

--- a/projects/ranger/src/app/map/action/map-action.component.spec.ts
+++ b/projects/ranger/src/app/map/action/map-action.component.spec.ts
@@ -1,0 +1,31 @@
+import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
+import {
+  async,
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+
+import {MapActionComponent} from './map-action.component';
+
+describe('MapActionComponent', () => {
+  let component: MapActionComponent;
+  let fixture: ComponentFixture<MapActionComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ MapActionComponent ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MapActionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/ranger/src/app/map/action/map-action.component.ts
+++ b/projects/ranger/src/app/map/action/map-action.component.ts
@@ -1,0 +1,68 @@
+import {
+  Component,
+  OnInit
+} from '@angular/core';
+import {MapDataService} from '../data/map-data.service';
+import {MapDragService} from '../drag/map-drag.service';
+import {MapStateService} from '../state/map-state.service';
+
+@Component({
+  selector: 'app-map-action',
+  templateUrl: './map-action.component.html',
+  styleUrls: ['./map-action.component.scss'],
+})
+export class MapActionComponent implements OnInit {
+
+  constructor(
+    private mapDataService: MapDataService,
+    private mapStateService: MapStateService,
+    private mapDragService: MapDragService,
+  ) { }
+
+  ngOnInit() {}
+
+  settingsFabAction(event: Event) {
+    console.log('Settings Toggle');
+  }
+
+  /* TODO: Not currently defined as an action on the map. */
+  settingsToggleCrosshairs(event) {
+    event.srcEvent.stopPropagation();
+    console.log(
+      'Crosshairs: ' + this.mapStateService.settingsToggleCrosshairs()
+    );
+  }
+
+  settingsToggleLatLon(event: Event) {
+    // this.showLatLon = !this.showLatLon;
+    // TODO: CI-34 bring latLon replacement into here
+    // MapComponent.latLon.enableDisplay(this.showLatLon);
+    // console.log('Lat/Lon: ' + this.showLatLon);
+    console.log('Lat/Lon: ');
+  }
+
+  /**
+   * Flips the state of Auto Center.
+   *
+   * Generally, when using the map, it is dragged into position and
+   * we don't want the position to change until we've moved a significant
+   * distance. So, the state is usually false once we've started dragging
+   * the map. Once we've travelled to another location, it's good to let
+   * the map show us where we are currently. That's usually when this button
+   * will be hit -- to show us our current location.
+   *
+   * @param event is ignored at this time.
+   */
+  settingsToggleAutoCenter(event: Event) {
+    this.mapDragService.setAutoCenter(!this.mapDragService.isAutoCenter());
+  }
+
+  /* Respond to request to repaint the locations. */
+  refreshMap(event: Event) {
+    // this.openMapAtPosition(this.mapDataService.getCurrentPosition());
+    /* Clear existing list of locations. */
+    /* Trigger sending us another set of locations. */
+    this.mapDataService.resendAllLocations();
+  }
+
+}

--- a/projects/ranger/src/app/map/add-loc-button/add-loc-button.html
+++ b/projects/ranger/src/app/map/add-loc-button/add-loc-button.html
@@ -1,5 +1,5 @@
-<ion-fab right bottom>
-  <button ion-fab mini (tap)="addLocationAction($event)">
+<ion-fab horizontal="end" vertical="bottom">
+  <ion-fab-button size="small" (click)="addLocationAction($event)">
     <ion-icon name="add"></ion-icon>
-  </button>
+  </ion-fab-button>
 </ion-fab>

--- a/projects/ranger/src/app/map/add-loc-button/add-loc-button.ts
+++ b/projects/ranger/src/app/map/add-loc-button/add-loc-button.ts
@@ -1,8 +1,11 @@
-import {Component, Input} from '@angular/core';
+import {Component} from '@angular/core';
 import {Geoposition} from '@ionic-native/geolocation';
 import {NavController} from '@ionic/angular';
-import {LatLon, LocationService} from 'cr-lib';
-import {BehaviorSubject} from 'rxjs';
+import {
+  LatLon,
+  LocationService
+} from 'cr-lib';
+import {MapDataService} from '../data/map-data.service';
 // TODO: CI-32 Edit Page for adding a new location
 // import {LocEditPage} from '../../pages/loc-edit/loc-edit';
 
@@ -17,24 +20,25 @@ import {BehaviorSubject} from 'rxjs';
 })
 export class AddLocButtonComponent {
 
-  @Input() mapCenter: BehaviorSubject<Geoposition>;
-
   constructor(
-    public locationService: LocationService,
+    private locationService: LocationService,
+    private mapDataService: MapDataService,
     private navCtrl: NavController,
   ) {
     console.log('Hello AddLocButtonComponent Component');
   }
 
-  addLocationAction(event) {
-    event.srcEvent.stopPropagation();
-    const newGeoposition: Geoposition = this.mapCenter.getValue();
+  addLocationAction(event: Event) {
+    const newGeoposition: Geoposition = this.mapDataService.getReportedPosition();
     alert(JSON.stringify(newGeoposition.coords));
+
+    // TODO CI-37: LatLon <==> Geoposition translation
     const newLatLon = new LatLon();
     newLatLon.lat = newGeoposition.coords.latitude;
     newLatLon.lon = newGeoposition.coords.longitude;
     newLatLon.lng = newGeoposition.coords.longitude;
 
+    // TODO: Turn this into AttractionService
     this.locationService.proposeLocation(newLatLon)
       .subscribe(location => {
         // TODO: CI-32

--- a/projects/ranger/src/app/map/data/map-data.service.ts
+++ b/projects/ranger/src/app/map/data/map-data.service.ts
@@ -56,8 +56,13 @@ export class MapDataService {
   }
 
   /** Subject published when center of map is moved. */
-  public getReportedPosition(): Subject<Geoposition> {
+  public getReportedPositionSubject(): BehaviorSubject<Geoposition> {
     return this.reportedPosition;
+  }
+
+  /** Geoposition published when center of map is moved. */
+  public getReportedPosition(): Geoposition {
+    return this.reportedPosition.getValue();
   }
 
   public postInitialPosition(position: Geoposition): void {
@@ -80,8 +85,14 @@ export class MapDataService {
     /* Other caches here? */
   }
 
-  public sendMeNewLocations(addLocationFunction) {
-    this.locationToAdd$.subscribe(addLocationFunction);
+  /**
+   * Allows a Map Data client to be told whenever there is a new Attraction
+   * to be added to the map.
+   *
+   * @param addAttractionFunction accepts an Attraction.
+   */
+  public sendMeNewAttractions(addAttractionFunction) {
+    this.locationToAdd$.subscribe(addAttractionFunction);
   }
 
   /**
@@ -133,13 +144,15 @@ export class MapDataService {
 
   /**
    * Request that all currently cached locations be sent to the subscribers.
+   *
+   * NOTE: This does not refresh the cache from the back-end.
    */
   resendAllLocations() {
-    /* Requires an instance that implement iterable. */
+    /* `from()` requires an instance that implements iterable. */
     from(this.attractionByIdCache).pipe(
       filter((item) => !!item)
     ).subscribe(
-      (loc) => {this.locationToAdd$.next(loc); }
+      (attraction) => {this.locationToAdd$.next(attraction); }
     );
   }
 

--- a/projects/ranger/src/app/map/drag/map-drag.service.ts
+++ b/projects/ranger/src/app/map/drag/map-drag.service.ts
@@ -38,8 +38,7 @@ export class MapDragService {
   constructor(
     private mapDataService: MapDataService
   ) {
-    // TODO: Not clear that I need this
-    this.centerSubject = mapDataService.getReportedPosition();
+    this.centerSubject = mapDataService.getReportedPositionSubject();
   }
 
   public isAutoCenter(): boolean {

--- a/projects/ranger/src/app/map/map.html
+++ b/projects/ranger/src/app/map/map.html
@@ -1,36 +1,7 @@
-<div class="map-content crosshairs" id="map">
+<div id="map" class="map-content crosshairs">
 
-  <!-- TODO: CI-36 take care of ion-fabs (and tap) -->
-  <ion-fab right top>
-    <button ion-fab mini (tap)="settingsFabAction($event)">
-      <ion-icon name="settings"></ion-icon>
-    </button>
-    <ion-fab-list>
+  <app-map-action></app-map-action>
 
-      <div class="labeledFab">
-        <ion-label>Toggle Lat/Lon</ion-label>
-        <button ion-fab (tap)="settingsToggleLatLon($event)">
-          <ion-icon name="checkmark"></ion-icon>
-        </button>
-      </div>
-
-      <div class="labeledFab">
-        <ion-label>Toggle Auto-center</ion-label>
-        <button ion-fab (tap)="settingsToggleAutoCenter($event)">
-          <ion-icon name="locate"></ion-icon>
-        </button>
-      </div>
-
-      <div class="labeledFab">
-        <ion-label>Refresh Map</ion-label>
-        <button ion-fab (tap)="refreshMap($event)">
-          <ion-icon name="refresh"></ion-icon>
-        </button>
-      </div>
-
-    </ion-fab-list>
-  </ion-fab>
-
-  <add-loc-button [mapCenter]="publiclyReportedPosition"></add-loc-button>
+  <add-loc-button></add-loc-button>
 
 </div>

--- a/projects/ranger/src/app/map/map.module.ts
+++ b/projects/ranger/src/app/map/map.module.ts
@@ -2,13 +2,15 @@ import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {IonicModule} from '@ionic/angular';
 import {HeadingModule} from 'cr-lib';
+import {MapActionComponent} from './action/map-action.component';
 import {AddLocButtonComponent} from './add-loc-button/add-loc-button';
 import {MapComponent} from './map';
 
 @NgModule({
   declarations: [
     MapComponent,
-    AddLocButtonComponent
+    AddLocButtonComponent,
+    MapActionComponent
   ],
   imports: [
     CommonModule,

--- a/projects/ranger/src/app/map/map.scss
+++ b/projects/ranger/src/app/map/map.scss
@@ -2,22 +2,6 @@ map {
 
 }
 
-.labeledFab {
-  overflow: visible;
-  position: relative;
-
-  ion-label {
-    position: absolute;
-    right: 40px;
-
-    color: white;
-    background-color: rgba(0,0,0,0.7);
-    line-height: 24px;
-    padding: 4px 8px;
-    border-radius: 4px;
-  }
-}
-
 .map-content { height: 100%; }
 
 .crosshairs:before, .crosshairs:after {

--- a/projects/ranger/src/app/map/map.ts
+++ b/projects/ranger/src/app/map/map.ts
@@ -35,10 +35,6 @@ export class MapComponent {
   /** Holds the current zoom for the map. */
   private zoomLevel: number;
 
-  private showLatLon = true;
-  private showCrosshairs = false;
-  private tethered = false;
-
   constructor(
     private navController: NavController,
     private heading: HeadingComponent,
@@ -49,7 +45,7 @@ export class MapComponent {
     this.zoomLevel = 14;
 
     console.log('Map Component constructing');
-    this.mapDataService.sendMeNewLocations(this.addAttraction);
+    this.mapDataService.sendMeNewAttractions(this.addAttraction);
   }
 
   /**
@@ -184,6 +180,7 @@ export class MapComponent {
       attraction,
       iconName
     );
+    console.log('Adding ' + attraction.name + ' to the map');
     poolMarker.on('click', (mouseEvent) => {
         this.openLocEditPageForMarkerClick(mouseEvent);
       });
@@ -210,44 +207,6 @@ export class MapComponent {
     //     tabId: MapComponent.getTabIdForLocation(attraction)
     //   }
     // );
-  }
-
-  settingsFabAction(event) {
-    event.srcEvent.stopPropagation();
-    console.log('Settings Toggle');
-  }
-
-  settingsToggleCrosshairs(event) {
-    event.srcEvent.stopPropagation();
-    this.showCrosshairs = !this.showCrosshairs;
-    console.log('Crosshairs: ' + this.showCrosshairs);
-  }
-
-  settingsToggleLatLon(event) {
-    event.srcEvent.stopPropagation();
-    this.showLatLon = !this.showLatLon;
-    // TODO: CI-34 bring latLon replacement into here
-    // MapComponent.latLon.enableDisplay(this.showLatLon);
-    console.log('Lat/Lon: ' + this.showLatLon);
-  }
-
-  settingsToggleAutoCenter(event) {
-    event.srcEvent.stopPropagation();
-    this.mapDragService.setAutoCenter(!this.mapDragService.isAutoCenter());
-  }
-
-  /* Respond to request to repaint the locations. */
-  refreshMap(event) {
-    event.srcEvent.stopPropagation();
-    this.openMapAtPosition(this.mapDataService.getCurrentPosition());
-    /* Clear existing list of locations. */
-    /* Trigger sending us another set of locations. */
-    this.mapDataService.resendAllLocations();
-  }
-
-  /* Won't be appropriate for Loc Edit. */
-  settingsToggleTether() {
-    this.tethered = !this.tethered;
   }
 
 }

--- a/projects/ranger/src/app/map/state/map-state.service.spec.ts
+++ b/projects/ranger/src/app/map/state/map-state.service.spec.ts
@@ -1,0 +1,12 @@
+import {TestBed} from '@angular/core/testing';
+
+import {MapStateService} from './map-state.service';
+
+describe('MapStateService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: MapStateService = TestBed.get(MapStateService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/ranger/src/app/map/state/map-state.service.ts
+++ b/projects/ranger/src/app/map/state/map-state.service.ts
@@ -1,0 +1,30 @@
+import {Injectable} from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MapStateService {
+
+  /* May want subjects for these values. */
+  private showLatLon = true;
+  private showCrosshairs = false;
+
+  constructor() {
+    /* Defaults to on, but may want to eventually persist this state. */
+    this.showCrosshairs = true;
+    this.showLatLon = true;
+  }
+
+  /** Toggles the showCrosshairs state and returns the new state. */
+  settingsToggleCrosshairs(): boolean {
+    this.showCrosshairs = !this.showCrosshairs;
+    return this.showCrosshairs;
+  }
+
+  /** Toggles the showLatLonView state and returns the new state. */
+  settingsToggleViewLatLon(): boolean {
+    this.showLatLon = !this.showLatLon;
+    return this.showLatLon;
+  }
+
+}


### PR DESCRIPTION
- Adds `map-action` component for the main FAB for settings.
- Adds MapStateService to track those settings separately from the Map.
- Further tidies up the MapDataService.
- Changes the Add Location Button to also follow the new rules (Event propagation).
- Removes the `map` code to the appropriate services.
- Makes some adjustments to the FAB styling now that we have a different
set of styles.