### PR TITLE
CI-42 Ranger Image Capture Page

### DIFF
--- a/projects/ranger/package-lock.json
+++ b/projects/ranger/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "loc-edit",
+  "name": "ranger",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -1267,6 +1267,21 @@
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
           "dev": true
+        }
+      }
+    },
+    "@ionic-native/camera": {
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@ionic-native/camera/-/camera-5.19.0.tgz",
+      "integrity": "sha512-aeLMhyj/AA3LCPXb05HjHb++UzkY4YqBpGhcXjcPCPcEsQl9RDfUYbp77LEDWdDvCAnQrpnJah2pyaWYp6ewuQ==",
+      "requires": {
+        "@types/cordova": "^0.0.34"
+      },
+      "dependencies": {
+        "@types/cordova": {
+          "version": "0.0.34",
+          "resolved": "https://registry.npmjs.org/@types/cordova/-/cordova-0.0.34.tgz",
+          "integrity": "sha1-6nrd907Ow9dimCegw54smt3HPQQ="
         }
       }
     },
@@ -3258,6 +3273,11 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
+    },
+    "cordova-plugin-camera": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-camera/-/cordova-plugin-camera-4.1.0.tgz",
+      "integrity": "sha512-fCLhWjWYn49q3X5xaypAPgTz6MAWSKFFQvD2Gpi5SuVlrRPRphtX2jIqR2zCBuDTBR082QVnlc+yUDXt65Mjgw=="
     },
     "cordova-plugin-customurlscheme": {
       "version": "5.0.0",

--- a/projects/ranger/package.json
+++ b/projects/ranger/package.json
@@ -20,6 +20,7 @@
     "@angular/platform-browser": "~8.1.2",
     "@angular/platform-browser-dynamic": "~8.1.2",
     "@angular/router": "~8.1.2",
+    "@ionic-native/camera": "^5.19.0",
     "@ionic-native/core": "^5.0.0",
     "@ionic-native/safari-view-controller": "^5.18.0",
     "@ionic-native/splash-screen": "^5.0.0",
@@ -28,6 +29,7 @@
     "@ionic/pro": "2.0.4",
     "cordova-android": "8.1.0",
     "cordova-ios": "5.1.1",
+    "cordova-plugin-camera": "^4.1.0",
     "cordova-plugin-customurlscheme": "5.0.0",
     "cordova-plugin-safariviewcontroller": "1.6.0",
     "core-js": "^2.5.4",
@@ -82,7 +84,8 @@
         "ANDROID_SCHEME": "com.clueride.ranger",
         "ANDROID_HOST": "clueride-shared.auth0.com",
         "ANDROID_PATHPREFIX": "/cordova/com.clueride.ranger/callback"
-      }
+      },
+      "cordova-plugin-camera": {}
     },
     "platforms": [
       "ios",

--- a/projects/ranger/src/app/app-routing.module.ts
+++ b/projects/ranger/src/app/app-routing.module.ts
@@ -23,6 +23,7 @@ const routes: Routes = [
   { path: 'edit', loadChildren: './edit/edit.module#EditPageModule' },
   /* Lazy loading for the Images Edit; wasn't able to make this a child of the Place Tab. */
   { path: 'images/:id', loadChildren: './images/images.module#ImagesPageModule' },
+  { path: 'image-capture', loadChildren: './image-capture/image-capture.module#ImageCapturePageModule' },
 ];
 
 @NgModule({

--- a/projects/ranger/src/app/edit/place-tab/place-tab.page.html
+++ b/projects/ranger/src/app/edit/place-tab/place-tab.page.html
@@ -46,7 +46,7 @@
           </ion-col>
           <ion-col>
             <ion-buttons>
-              <ion-button [disabled]="true">
+              <ion-button (click)="imageFromGallery()">
                 From Gallery
               </ion-button>
             </ion-buttons>

--- a/projects/ranger/src/app/edit/place-tab/place-tab.page.ts
+++ b/projects/ranger/src/app/edit/place-tab/place-tab.page.ts
@@ -114,21 +114,25 @@ export class PlaceTabPage implements OnInit, OnDestroy {
   /** Opens the Page that performs Camera operations passing the the attraction and the "Camera" flag. */
   captureImage() {
     console.log('Opening Camera');
-    // TODO: CI-42 Image Capture Page
-    // this.navCtrl.push(ImageCapturePage, {
-    //   attraction: this.attraction,
-    //   mode: 'camera'
-    // });
+    this.router.navigate(
+      ['image-capture'],
+      {state: {
+          attraction: this.attraction,
+          mode: 'camera'
+        }}
+    );
   }
 
   /** Opens the Page that performs Gallery upload operations passing the the attraction and the "Gallery" flag. */
   imageFromGallery() {
     console.log('Opening Gallery');
-    // TODO: CI-42 Image Capture Page
-    // this.navCtrl.push(ImageCapturePage, {
-    //   attraction: this.attraction,
-    //   mode: 'gallery'
-    // });
+    this.router.navigate(
+      ['image-capture'],
+      {state: {
+          attraction: this.attraction,
+          mode: 'gallery'
+        }}
+    );
   }
 
   showOtherImages() {

--- a/projects/ranger/src/app/image-capture/image-capture.module.ts
+++ b/projects/ranger/src/app/image-capture/image-capture.module.ts
@@ -1,0 +1,33 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {
+  RouterModule,
+  Routes
+} from '@angular/router';
+import {Camera} from '@ionic-native/camera/ngx';
+
+import {IonicModule} from '@ionic/angular';
+import {ConnectionStateModule} from 'cr-lib';
+
+import {ImageCapturePage} from './image-capture.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ImageCapturePage
+  }
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ConnectionStateModule,
+    FormsModule,
+    IonicModule,
+    RouterModule.forChild(routes)
+  ],
+  declarations: [ImageCapturePage],
+  providers: [Camera]
+})
+export class ImageCapturePageModule {}

--- a/projects/ranger/src/app/image-capture/image-capture.page.html
+++ b/projects/ranger/src/app/image-capture/image-capture.page.html
@@ -1,0 +1,48 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Capture Image for {{attraction.name}}</ion-title>
+    <ion-buttons slot="end">
+      <cr-connection-state></cr-connection-state>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+
+  <div id="image-capture">
+    <label>
+      Candidate Image:
+    </label>
+
+    <div *ngIf="haveImagesToShow()">
+
+      <ion-slides>
+        <ion-slide *ngFor="let image of images">
+          <ion-card>
+            <!-- Unable to use ion-img here; does it support base64? -->
+            <img [src]="image.src"/>
+          </ion-card>
+        </ion-slide>
+      </ion-slides>
+
+      <ion-buttons>
+        <ion-button
+                (click)="save()">
+          Save as new Image
+        </ion-button>
+      </ion-buttons>
+
+    </div>
+
+    <div *ngIf="!haveImagesToShow()">
+      No images yet.
+      <ion-buttons>
+        <ion-button (click)="fakeImage()">
+          Save fake Image
+        </ion-button>
+      </ion-buttons>
+    </div>
+
+  </div>
+
+</ion-content>

--- a/projects/ranger/src/app/image-capture/image-capture.page.spec.ts
+++ b/projects/ranger/src/app/image-capture/image-capture.page.spec.ts
@@ -1,0 +1,31 @@
+import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
+import {
+  async,
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+
+import {ImageCapturePage} from './image-capture.page';
+
+describe('ImageCapturePage', () => {
+  let component: ImageCapturePage;
+  let fixture: ComponentFixture<ImageCapturePage>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ImageCapturePage ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ImageCapturePage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/ranger/src/app/image-capture/image-capture.page.ts
+++ b/projects/ranger/src/app/image-capture/image-capture.page.ts
@@ -1,0 +1,130 @@
+import {
+  Component,
+  OnInit
+} from '@angular/core';
+import {
+  ActivatedRoute,
+  NavigationExtras,
+  Router
+} from '@angular/router';
+import {
+  Camera,
+  CameraOptions
+} from '@ionic-native/camera/ngx';
+import {LoadingController} from '@ionic/angular';
+import {
+  Attraction,
+  ImageService
+} from 'cr-lib';
+import {from} from 'rxjs';
+
+@Component({
+  selector: 'app-image-capture',
+  templateUrl: './image-capture.page.html',
+  styleUrls: ['./image-capture.page.scss']
+})
+export class ImageCapturePage implements OnInit {
+
+  /* Exposed to the View: */
+  public attraction: Attraction;
+  public base64Image: string;
+  public images: Array<any> = [];
+
+  private cameraOptions: CameraOptions = {
+    correctOrientation: true,
+    destinationType: this.camera.DestinationType.DATA_URL,
+    encodingType: this.camera.EncodingType.JPEG,
+    quality: 90,
+    targetWidth: 1000,
+    targetHeight: 1000
+  };
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private camera: Camera,
+    private imageService: ImageService,
+    private loadingCtrl: LoadingController,
+  ) { }
+
+  ngOnInit() {
+    this.route.queryParams.subscribe(
+      (params) => {
+        if (this.router.getCurrentNavigation().extras.state) {
+          const extras: NavigationExtras = this.router.getCurrentNavigation().extras;
+          this.attraction = extras.state.attraction;
+
+          if (extras.state.mode === 'gallery') {
+            this.cameraOptions.sourceType = this.camera.PictureSourceType.PHOTOLIBRARY;
+          }
+        }
+      }
+    );
+  }
+
+  ionViewWillEnter() {
+    console.log('ionViewWillEnter ImageCapturePage');
+    this.camera.getPicture(
+      this.cameraOptions
+    ).then((imageData) => {
+      //   imageData is a base64 encoded string
+      this.base64Image = 'data:image/jpeg;base64,' + imageData;
+      this.images.unshift(
+        {src: this.base64Image}
+      );
+    }, (err) => {
+      console.log(err);
+    });
+  }
+
+  public haveImagesToShow(): boolean {
+    return (this.images.length > 0);
+  }
+
+  public async save() {
+    const loading = await this.loadingCtrl.create(
+      {
+        message: 'Finding a good spot for that fine picture ...'
+      }
+    );
+    await loading.present();
+
+    this.imageService.uploadImage(
+      this.bundleImageForSaving()
+    ).subscribe(
+      (uploadedImage) => {
+        console.log('New Image ID: ' + uploadedImage.id);
+        loading.dismiss();
+        from (this.router.navigate(['images', this.attraction.id])).subscribe(
+          () => {console.log('Have returned from Image Capture'); }
+        );
+      }
+    );
+  }
+
+  /**
+   * Takes the captured image and bundles it up for posting to the ImageService for upload.
+   */
+  bundleImageForSaving(): FormData {
+    const formData = new FormData();
+    const image = {
+      locationId: this.attraction.id,
+      lat: this.attraction.latLon.lat,
+      lon: this.attraction.latLon.lon,
+      fileData: new FormData()
+    };
+
+    const blob = new Blob([this.images[0].src], {type: 'image/jpeg'});
+    formData.append('locationId', '' + image.locationId);
+    formData.append('lat', '' + image.lat);
+    formData.append('lon', '' + image.lon);
+    formData.append('fileData', blob, 'cameraImage.jpg');
+
+    return formData;
+  }
+
+  fakeImage() {
+    this.images.unshift({src: 'Test Data'});
+  }
+
+}


### PR DESCRIPTION
- Brings image-capture page over from mobiLoc and adjusts for Ionic 4.
- Turns on the gallery feature of the camera.

This commit depends on installing the native Camera support for
Ionic and Cordova which is described on the ticket.