### PR TITLE
CI-60 Refactor the new attraction away from the updated attraction

### DIFF
--- a/projects/ranger/src/app/home/home.page.ts
+++ b/projects/ranger/src/app/home/home.page.ts
@@ -1,4 +1,8 @@
-import {AfterContentInit, Component, ViewChild} from '@angular/core';
+import {
+  AfterContentInit,
+  Component,
+  ViewChild
+} from '@angular/core';
 import {Title} from '@angular/platform-browser';
 import {MapDataService} from '../map/data/map-data.service';
 import {MapComponent} from '../map/map';
@@ -23,17 +27,18 @@ export class HomePage implements AfterContentInit {
     this.titleService.setTitle('Home');
   }
 
+  /**
+   * Tell the Map Component that we're ready to plop down an implementation of the Map.
+   *
+   * Dimensions of the Map content aren't known until we're about to
+   * enter the Page's view; the component itself can't tell.
+   *
+   * Components do implement the onInit and onDestroy, so we don't need notification
+   * for shutting down the page. No need for `ionViewWillLeave()`.
+   */
   ionViewWillEnter() {
     console.log('Map/Home Page: Will Enter');
-    this.map.openMap(this.mapDataService.getCurrentPositionSubject());
-  }
-
-  /**
-   * Life-Cycle events are tracked at the View level.
-   */
-  ionViewWillLeave() {
-    console.log('Map/Home Page: Will Leave');
-    this.map.closeMap();
+    this.map.openMap();
   }
 
 }


### PR DESCRIPTION
- Replicates the add attraction as an update attraction.
- Adds a layer group for holding the markers (and later removing them).
- Beefs up the understanding of waiting for the *view* to settle before
we can create the map instance; kicks off the Leaflet Map implementation
after the containing page is about to enter the View (meaning all components
are assembled and scoped out for size, maybe?).

Performs a bit more of the conversion from Location to Attraction.

This work also identified other spots that need attention and ties together
some of the outstanding problems we've faced with the Map life-cycle.