### PR TITLE
CI-56 Add ion-alert-controller to provide for badge notifications and…

### DIFF
--- a/projects/cr-lib/src/lib/alert/alert.module.ts
+++ b/projects/cr-lib/src/lib/alert/alert.module.ts
@@ -1,0 +1,21 @@
+import {CommonModule} from '@angular/common';
+import {HTTP_INTERCEPTORS} from '@angular/common/http';
+import {NgModule} from '@angular/core';
+import {IonicModule} from '@ionic/angular';
+import {HttpErrorInterceptor} from './http-error.interceptor';
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule,
+    IonicModule
+  ],
+  providers: [
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: HttpErrorInterceptor,
+      multi: true
+    }
+  ]
+})
+export class AlertToastModule { }

--- a/projects/cr-lib/src/lib/alert/http-error.interceptor.ts
+++ b/projects/cr-lib/src/lib/alert/http-error.interceptor.ts
@@ -1,0 +1,60 @@
+import {
+  HttpErrorResponse,
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest
+} from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import {ToastController} from '@ionic/angular';
+import {
+  Observable,
+  throwError
+} from 'rxjs';
+import {catchError} from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class HttpErrorInterceptor implements HttpInterceptor {
+
+  constructor(
+    private toastController: ToastController
+  ) {}
+
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    return next.handle(request)
+      .pipe(
+        /* Not clear that I'll want retries just yet. */
+        // retry(1),
+        catchError((error: HttpErrorResponse) => {
+          let errorMessage = '';
+          if (error.error instanceof ErrorEvent) {
+            // client-side error
+            errorMessage = `Error: ${error.error.message}`;
+          } else {
+            // server-side error
+            errorMessage = `Message: ${error.error}`;
+          }
+          this.presentToast(error, errorMessage);
+
+          return throwError(errorMessage);
+        })
+      );
+  }
+
+  async presentToast(
+    error: HttpErrorResponse,
+    messageToShow: string
+  ) {
+    const toast = await this.toastController.create({
+      header: 'Status: ' + error.statusText + '(' + error.status + ')',
+      message: messageToShow,
+      duration: 6000,
+      showCloseButton: true,
+      color: 'danger'
+    });
+    toast.present();
+  }
+
+}

--- a/projects/cr-lib/src/public-api.ts
+++ b/projects/cr-lib/src/public-api.ts
@@ -2,6 +2,8 @@
  * Public API Surface of cr-lib
  */
 
+export * from './lib/alert/alert.module';
+export * from './lib/alert/http-error.interceptor';
 export * from './lib/api/attraction/attraction';
 export * from './lib/api/attraction/attraction.service';
 export * from './lib/api/badge/badge';

--- a/projects/ranger/src/app/app.module.ts
+++ b/projects/ranger/src/app/app.module.ts
@@ -10,6 +10,7 @@ import {
   IonicRouteStrategy
 } from '@ionic/angular';
 import {
+  AlertToastModule,
   AuthModule,
   HeadingModule
 } from 'cr-lib';
@@ -23,6 +24,7 @@ import {AppComponent} from './app.component';
   imports: [
     BrowserModule,
     IonicModule.forRoot(),
+    AlertToastModule,
     AppRoutingModule,
     AuthModule,
     HeadingModule,


### PR DESCRIPTION
… other messages

- Adds AlertToastModule that provides a Toast Message when there is
an untrapped exception from the server API.
- Overrides default HTTP Error response to peel off the wrapped message
coming from the server when an exception is thrown.