### PR TITLE
CI-77 Introduce SSE service to seeker Ionic 4

### DIFF
--- a/projects/cr-lib/src/lib/api/profile/README.md
+++ b/projects/cr-lib/src/lib/api/profile/README.md
@@ -10,4 +10,5 @@ Profile Service works with:
 - Back-end REST API to retrieve current session's Member record.
 - Clients requesting Email Address or the URL of the user's image.
 - Clients requesting the Member ID of logged in user.
+- Clients requesting the BadgeOS ID of logged in user.
 - Confirmation Page informs the profile of confirmation status and notifies listeners of this event.

--- a/projects/cr-lib/src/lib/api/profile/profile.service.ts
+++ b/projects/cr-lib/src/lib/api/profile/profile.service.ts
@@ -1,10 +1,19 @@
-import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
-import {BASE_URL, AuthHeaderService} from '../../auth/header/auth-header.service';
-import {Member} from '../member/member';
-import {Observable, of} from 'rxjs';
+import {Injectable} from '@angular/core';
+import {
+  Observable,
+  of
+} from 'rxjs';
+import {
+  map,
+  share
+} from 'rxjs/operators';
+import {
+  AuthHeaderService,
+  BASE_URL
+} from '../../auth/header/auth-header.service';
 import {TokenService} from '../../auth/token/token.service';
-import {map, share} from 'rxjs/operators';
+import {Member} from '../member/member';
 
 /**
  * Responsible for the Member's Profile.
@@ -115,6 +124,14 @@ export class ProfileService {
       }
     }
     return '';
+  }
+
+  public getBadgeOsId(): number {
+    if (this.member) {
+      return this.member.badgeOSId;
+    } else {
+      return -1;
+    }
   }
 
   public getGivenName(): string {

--- a/projects/cr-lib/src/lib/sse-event/answer-summary/answer-post.ts
+++ b/projects/cr-lib/src/lib/sse-event/answer-summary/answer-post.ts
@@ -1,0 +1,13 @@
+import {AnswerKey} from '../../api/puzzle/answer';
+
+export class AnswerPost {
+  puzzleId: number;
+  answer: string;
+
+  constructor(puzzleId: number, myAnswer: AnswerKey) {
+    this.puzzleId = puzzleId;
+    this.answer = AnswerKey[myAnswer];
+  }
+
+}
+

--- a/projects/cr-lib/src/lib/sse-event/answer-summary/answer-summary.service.ts
+++ b/projects/cr-lib/src/lib/sse-event/answer-summary/answer-summary.service.ts
@@ -1,0 +1,68 @@
+import {HttpClient} from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import {
+  Observable,
+  Subscription
+} from 'rxjs';
+import {AnswerKey} from '../../api/puzzle/answer';
+import {
+  AuthHeaderService,
+  BASE_URL
+} from '../../auth/header/auth-header.service';
+import {ServerEventsService} from '../sse-event.service';
+import {AnswerPost} from './answer-post';
+import {AnswerSummary} from './answer-summary';
+
+/**
+ * Responsible for Answer Summaries.
+ *
+ * Posting Answers and following the stream of AnswerSummaries until the Puzzle is closed.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class AnswerSummaryService {
+
+  /* This life-cycle probably goes with the page. */
+  private subscription: Subscription;
+
+  constructor(
+    public http: HttpClient,
+    public httpService: AuthHeaderService,
+    public sseService: ServerEventsService,
+  ) {
+    console.log('Hello AnswerSummaryService');
+  }
+
+  public openAnswerSummaryChannel(): Observable<AnswerSummary> {
+    const answerSummary$: Observable<AnswerSummary> = this.sseService.getAnswerSummaryObservable();
+    this.subscription = answerSummary$.subscribe(
+      (answerSummary) => {
+        console.log('Answers received for puzzle ID: ' + answerSummary.puzzleId);
+      }
+    );
+    return answerSummary$;
+  }
+
+  public closeAnswerSummaryChannel(): void {
+    this.subscription.unsubscribe();
+  }
+
+  /**
+   * Send in player's answer and get back the current AnswerSummary.
+   * @param puzzleId unique identifier for the Puzzle we're answering.
+   * @param myAnswer AnswerKey matching the selected answer.
+   */
+  public postAnswer(
+    puzzleId: number,
+    myAnswer: AnswerKey
+  ): Observable<AnswerSummary> {
+    const answerPost = new AnswerPost(puzzleId, myAnswer);
+    return this.http.post<AnswerSummary>(
+      BASE_URL + 'puzzle/answer',
+      answerPost,
+      {headers: this.httpService.getAuthHeaders()}
+    );
+  }
+
+}

--- a/projects/cr-lib/src/lib/sse-event/answer-summary/answer-summary.ts
+++ b/projects/cr-lib/src/lib/sse-event/answer-summary/answer-summary.ts
@@ -1,0 +1,19 @@
+/**
+ * Count of the number of responses given for each Answer(Key).
+ */
+import {AnswerKey} from '../../api/puzzle/answer';
+
+interface AnswerMap {
+  /* The string should come from AnswerKey.[answerKey:AnswerKey]. */
+  [index: string]: number;
+}
+
+/**
+ * Maps to AnswerSummary.
+ */
+export class AnswerSummary {
+  puzzleId: number;
+  correctAnswer: AnswerKey;
+  myAnswer: AnswerKey;
+  answerMap: AnswerMap;
+}

--- a/projects/cr-lib/src/lib/sse-event/badge-event.ts
+++ b/projects/cr-lib/src/lib/sse-event/badge-event.ts
@@ -1,0 +1,9 @@
+import {BadgeFeatures} from '../api/badge-progress/badge-features';
+
+/**
+ * SSE sends this when a Badge is awarded.
+ */
+export class BadgeEvent {
+  userId: number;
+  badgeFeatures: BadgeFeatures;
+}

--- a/projects/cr-lib/src/lib/sse-event/sse-event.service.ts
+++ b/projects/cr-lib/src/lib/sse-event/sse-event.service.ts
@@ -1,8 +1,22 @@
-import {EventSourcePolyfill} from 'ng-event-source';
-import {HttpClient} from '@angular/common/http';
-import {AuthHeaderService, SSE_EVENT_BASE_URL} from '../auth/header/auth-header.service';
 import {Injectable} from '@angular/core';
-import {TokenService} from '../auth/token/token.service';
+import {
+  EventSourcePolyfill,
+  OnMessageEvent
+} from 'ng-event-source';
+import {
+  Observable,
+  Subject
+} from 'rxjs';
+import {
+  filter,
+  map
+} from 'rxjs/operators';
+import {ProfileService} from '../api/profile/profile.service';
+import {AuthHeaderService} from '../auth/header/auth-header.service';
+import {AnswerSummary} from './answer-summary/answer-summary';
+import {BadgeEvent} from './badge-event';
+
+const gameStateUrl = 'http://sse.clueride.com/game-state-broadcast';
 
 /**
  * Handles subscriptions to the SSE Server.
@@ -12,38 +26,120 @@ import {TokenService} from '../auth/token/token.service';
 @Injectable({
   providedIn: 'root'
 })
-export class SseEventService {
+export class ServerEventsService {
 
-  /* Lazy init. */
-  static eventSource: EventSourcePolyfill = null;
+  private eventSource: EventSourcePolyfill;
+
+  private answerSummary$: Subject<OnMessageEvent>;
+  readonly badgeEvent$: Subject<string>;
+  private gameStateEvent$: Subject<OnMessageEvent>;
+  private tetherEvent$: Subject<OnMessageEvent>;
 
   constructor(
-    public http: HttpClient,
-    public httpService: AuthHeaderService,
+    private authHeaderService: AuthHeaderService,
+    private profileService: ProfileService,
   ) {
-    console.log('Hello SseEventService Provider');
+    this.answerSummary$ = new Subject<OnMessageEvent>();
+    this.badgeEvent$ = new Subject<string>();
+    this.gameStateEvent$ = new Subject<OnMessageEvent>();
+    this.tetherEvent$ = new Subject<OnMessageEvent>();
   }
 
   getEventSource(): EventSourcePolyfill {
-    if (SseEventService.eventSource == null) {
-      SseEventService.eventSource = this.initializeEventSource();
+    if (this.eventSource == null) {
+      this.initializeSubscriptions(null);
     }
-    return SseEventService.eventSource;
+    return this.eventSource;
   }
 
   /**
-   * Invoked to prepare connection to SSE Server and begin emitting
-   * the events that come in on that channel.
+   * Handles life-cycle for Game State events on the channel for the given Outing ID.
+   *
+   * TODO: It shouldn't be all messages:
+   * All Messages are forwarded to the GameStateService for triggering UI changes.
+   *
+   * @param outingId the unique ID for the Outing we're paying attention to.
    */
-  initializeEventSource(): EventSourcePolyfill {
-    const bearerToken = TokenService.getBearerToken();
-    return new EventSourcePolyfill(
-      SSE_EVENT_BASE_URL + 'sse-channel',
-      {
-        headers: {
-          Authorization: `Bearer ${bearerToken}`
-        }
+  public initializeSubscriptions(outingId: number): void {
+
+    if (!this.eventSource) {
+      console.log('Opening Event Source');
+      let eventSourceUrl = gameStateUrl;
+      /* Event Source may or may not be paying attention to a specific Outing. */
+      if (outingId) {
+        eventSourceUrl += '/' + outingId;
       }
+
+      this.eventSource = new EventSourcePolyfill(
+        eventSourceUrl,
+        {
+          headers: this.authHeaderService.getAuthHeaders()
+        }
+      );
+
+      /* All custom message types fire the `onmessage` event for our chosen EventSource polyfill. */
+      this.eventSource.onmessage = (
+        (messageEvent: MessageEvent) => {
+          console.log('SSE Message (type ' + messageEvent.type + '): ' + JSON.stringify(messageEvent.data));
+          /* Handle the various Named Messages. */
+          if (messageEvent.type === 'tether') {
+            this.tetherEvent$.next(messageEvent);
+          } else if (messageEvent.type === 'message' || messageEvent.type === 'game_state') {
+            this.gameStateEvent$.next(messageEvent);
+          } else if (messageEvent.type === 'badge-award') {
+            this.badgeEvent$.next(messageEvent.data);
+          } else if (messageEvent.type === 'answer-summary') {
+            this.answerSummary$.next(messageEvent);
+          } else {
+            console.error('Unrecognized Message Type: ', messageEvent.type);
+          }
+        }
+      );
+
+      this.eventSource.onopen = (
+        (openEvent) => {
+          console.log('SSE Open: ' + JSON.stringify(openEvent));
+        }
+      );
+
+      this.eventSource.onerror = (
+        (error) => {
+          console.log('SSE Error: ' + JSON.stringify(error));
+        }
+      );
+
+    }
+
+  }
+
+  /**
+   * Observable that streams the answer-summary events.
+   */
+  public getAnswerSummaryObservable(): Observable<AnswerSummary> {
+    return this.answerSummary$.pipe(
+      map(event => {
+        return JSON.parse(event.data).answerSummary;
+      })
+    );
+  }
+
+  public getBadgeEventObservable(): Observable<BadgeEvent> {
+    return this.badgeEvent$.pipe(
+      map(eventData => {
+        return JSON.parse(eventData);
+      }),
+      filter(
+        /* Check that this badge award is for this session's user. */
+        badgeEvent => (badgeEvent.userId === this.profileService.getBadgeOsId()))
+      );
+  }
+
+  /**
+   * Observable that streams Game State events.
+   */
+  public getGameStateEventObservable(): Observable<any> {
+    return this.gameStateEvent$.pipe(
+      map( event => JSON.parse(event.data))
     );
   }
 

--- a/projects/cr-lib/src/lib/state/connection/connection-state.ts
+++ b/projects/cr-lib/src/lib/state/connection/connection-state.ts
@@ -1,13 +1,11 @@
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 import {EventSourcePolyfill} from 'ng-event-source';
-import {SseEventService} from '../../sse-event/sse-event.service';
+import {ServerEventsService} from '../../sse-event/sse-event.service';
 
 /**
  * Reports on the status of the Event Source setup by our SSE Event Service.
  */
 @Component({
-  // TODO: CI-11 Update references to this component's selector.
-  // selector: 'connection-state',
   selector: 'cr-connection-state',
   templateUrl: 'connection-state.html'
 })
@@ -16,10 +14,10 @@ export class ConnectionStateComponent {
   private eventSource: EventSourcePolyfill;
 
   constructor(
-    sseEventService: SseEventService
+    private serverEventsService: ServerEventsService
   ) {
     console.log('Hello ConnectionStateComponent Component');
-    this.eventSource = sseEventService.getEventSource();
+    this.eventSource = serverEventsService.getEventSource();
   }
 
   public isOpen(): boolean {

--- a/projects/player/src/app/app-routing.module.ts
+++ b/projects/player/src/app/app-routing.module.ts
@@ -1,5 +1,9 @@
-import { NgModule } from '@angular/core';
-import { PreloadAllModules, RouterModule, Routes } from '@angular/router';
+import {NgModule} from '@angular/core';
+import {
+  PreloadAllModules,
+  RouterModule,
+  Routes
+} from '@angular/router';
 
 const routes: Routes = [
   {
@@ -14,7 +18,9 @@ const routes: Routes = [
   {
     path: 'list',
     loadChildren: () => import('./list/list.module').then(m => m.ListPageModule)
-  }
+  },
+  { path: 'rolling', loadChildren: './rolling/rolling.module#RollingPageModule' },
+  { path: 'puzzle', loadChildren: './puzzle/puzzle.module#PuzzlePageModule' }
 ];
 
 @NgModule({

--- a/projects/player/src/app/game/game-state.service.ts
+++ b/projects/player/src/app/game/game-state.service.ts
@@ -2,7 +2,8 @@ import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {
   AuthHeaderService,
-  BASE_URL
+  BASE_URL,
+  ServerEventsService
 } from 'cr-lib';
 import {
   Observable,
@@ -28,7 +29,7 @@ export class GameStateService {
   constructor(
     private http: HttpClient,
     private authHeaderService: AuthHeaderService,
-    // private sseService: ServerEventsService,
+    private sseService: ServerEventsService,
   ) {
     console.log('Hello GameStateService Provider');
     this.puzzleEvent$ = new Subject<GameState>();
@@ -49,10 +50,10 @@ export class GameStateService {
 
   setupSseEventSubscription() {
     console.log('Listening to SSE Events for Game State');
-    // this.sseSubscription = this.sseService.getGameStateEventObservable()
-    //   .subscribe(
-    //     (event) => this.updateFromSSE(event)
-    //   );
+    this.sseSubscription = this.sseService.getGameStateEventObservable()
+      .subscribe(
+        (event) => this.updateFromSSE(event)
+      );
   }
 
   ngOnInit() {

--- a/projects/player/src/app/puzzle/puzzle.module.ts
+++ b/projects/player/src/app/puzzle/puzzle.module.ts
@@ -1,0 +1,29 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {
+  RouterModule,
+  Routes
+} from '@angular/router';
+
+import {IonicModule} from '@ionic/angular';
+
+import {PuzzlePage} from './puzzle.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: PuzzlePage
+  }
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    RouterModule.forChild(routes)
+  ],
+  declarations: [PuzzlePage]
+})
+export class PuzzlePageModule {}

--- a/projects/player/src/app/puzzle/puzzle.page.html
+++ b/projects/player/src/app/puzzle/puzzle.page.html
@@ -1,0 +1,9 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Puzzle</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+
+</ion-content>

--- a/projects/player/src/app/puzzle/puzzle.page.spec.ts
+++ b/projects/player/src/app/puzzle/puzzle.page.spec.ts
@@ -1,0 +1,31 @@
+import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
+import {
+  async,
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+
+import {PuzzlePage} from './puzzle.page';
+
+describe('PuzzlePage', () => {
+  let component: PuzzlePage;
+  let fixture: ComponentFixture<PuzzlePage>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PuzzlePage ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PuzzlePage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/player/src/app/puzzle/puzzle.page.ts
+++ b/projects/player/src/app/puzzle/puzzle.page.ts
@@ -1,0 +1,18 @@
+import {
+  Component,
+  OnInit
+} from '@angular/core';
+
+@Component({
+  selector: 'app-puzzle',
+  templateUrl: './puzzle.page.html',
+  styleUrls: ['./puzzle.page.scss'],
+})
+export class PuzzlePage implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/projects/player/src/app/rolling/rolling.module.ts
+++ b/projects/player/src/app/rolling/rolling.module.ts
@@ -1,0 +1,29 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {
+  RouterModule,
+  Routes
+} from '@angular/router';
+
+import {IonicModule} from '@ionic/angular';
+
+import {RollingPage} from './rolling.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: RollingPage
+  }
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    RouterModule.forChild(routes)
+  ],
+  declarations: [RollingPage]
+})
+export class RollingPageModule {}

--- a/projects/player/src/app/rolling/rolling.page.html
+++ b/projects/player/src/app/rolling/rolling.page.html
@@ -1,0 +1,9 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Rolling</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+
+</ion-content>

--- a/projects/player/src/app/rolling/rolling.page.spec.ts
+++ b/projects/player/src/app/rolling/rolling.page.spec.ts
@@ -1,0 +1,31 @@
+import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
+import {
+  async,
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+
+import {RollingPage} from './rolling.page';
+
+describe('RollingPage', () => {
+  let component: RollingPage;
+  let fixture: ComponentFixture<RollingPage>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ RollingPage ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RollingPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/player/src/app/rolling/rolling.page.ts
+++ b/projects/player/src/app/rolling/rolling.page.ts
@@ -1,0 +1,18 @@
+import {
+  Component,
+  OnInit
+} from '@angular/core';
+
+@Component({
+  selector: 'app-rolling',
+  templateUrl: './rolling.page.html',
+  styleUrls: ['./rolling.page.scss'],
+})
+export class RollingPage implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}


### PR DESCRIPTION
- Amends existing SSE Event Service in cr-lib with the service defined for player.
- Brings in the actual events pushed by SSE: BadgeEvent and AnswerSummary on top
of the existing GameState.
- Adds shells for the Rolling and Puzzle pages.
- Amends the profile service to return BadgeOS ID.

There is still some work to be done regarding the Outing-based vs. non-outing-based
modes. Opened as a separate ticket: CI-82.