### PR TITLE
CI-95 Profile Service should pre-emptively load for a session

### DIFF
--- a/projects/cr-lib/src/lib/api/profile/profile.service.ts
+++ b/projects/cr-lib/src/lib/api/profile/profile.service.ts
@@ -50,6 +50,7 @@ export class ProfileService {
     private authHeaderService: AuthHeaderService,
     private tokenService: TokenService,
   ) {
+    console.log('ProfileService: Constructing');
   }
 
   /**

--- a/projects/cr-lib/src/lib/auth/client-api/await-registration.service.ts
+++ b/projects/cr-lib/src/lib/auth/client-api/await-registration.service.ts
@@ -1,7 +1,18 @@
-import {Injectable, NgZone} from '@angular/core';
+import {
+  Injectable,
+  NgZone
+} from '@angular/core';
 import {NavController} from '@ionic/angular';
-import {Observable, ReplaySubject, Subject} from 'rxjs';
-import {filter, find} from 'rxjs/operators';
+import {
+  Observable,
+  ReplaySubject,
+  Subject
+} from 'rxjs';
+import {
+  filter,
+  find
+} from 'rxjs/operators';
+import {ProfileService} from '../../api/profile/profile.service';
 import {RegStateKey} from '../state/reg-state-key';
 import {RegStateService} from '../state/reg-state.service';
 
@@ -18,6 +29,7 @@ export class AwaitRegistrationService {
   constructor(
     private regStateService: RegStateService,
     private nav: NavController,
+    private profileService: ProfileService,
     private zone: NgZone,
   ) {
     this.registrationActiveSubject = new ReplaySubject();
@@ -69,8 +81,14 @@ export class AwaitRegistrationService {
       find(regState => regState.state === RegStateKey.ACTIVE)
     ).subscribe(regState => {
       console.log('Active by the grace of', regState.source );
-      /* Proceed with the application. */
-      this.registrationActiveSubject.next(true);
+      /* Now able to load ProfileService. */
+      this.profileService.loadMemberProfile().subscribe(
+        () => {
+          console.log('Profile is loaded for user', this.profileService.getDisplayName());
+          /* Proceed with the application. */
+          this.registrationActiveSubject.next(true);
+        }
+      );
     });
 
     return this.registrationActiveSubject.asObservable();

--- a/projects/player/src/app/app.component.ts
+++ b/projects/player/src/app/app.component.ts
@@ -5,9 +5,11 @@ import {StatusBar} from '@ionic-native/status-bar/ngx';
 import {Platform} from '@ionic/angular';
 import {
   AwaitRegistrationService,
-  PlatformStateService
+  PlatformStateService,
+  ProfileService
 } from 'cr-lib';
 import {AppStateService} from './state/app/app-state.service';
+import {LoadStateService} from './state/load/load-state-service.service';
 
 @Component({
   selector: 'app-root',
@@ -30,8 +32,10 @@ export class AppComponent {
 
   constructor(
     private appStateService: AppStateService,
+    private loadStateService: LoadStateService,
     private platform: Platform,
     private platformStateService: PlatformStateService,
+    private profileService: ProfileService,
     private authClient: AwaitRegistrationService,
     private splashScreen: SplashScreen,
     private statusBar: StatusBar
@@ -54,9 +58,14 @@ export class AppComponent {
           if (ready) {
             console.log('Registered');
             /* Proceed with the application. */
-            this.appStateService.checkInviteIsAccepted()
-              .then()
-              .catch();
+            this.profileService.loadMemberProfile().subscribe(
+              () => {
+                this.appStateService.checkInviteIsAccepted()
+                  .then()
+                  .catch();
+                this.loadStateService.loadOutingData();
+              }
+            );
           }
         });
     });

--- a/projects/player/src/app/rolling/rolling.guard.spec.ts
+++ b/projects/player/src/app/rolling/rolling.guard.spec.ts
@@ -1,0 +1,18 @@
+import {
+  inject,
+  TestBed
+} from '@angular/core/testing';
+
+import {RollingGuard} from './rolling.guard';
+
+describe('RollingGuardGuard', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [RollingGuard]
+    });
+  });
+
+  it('should ...', inject([RollingGuard], (guard: RollingGuard) => {
+    expect(guard).toBeTruthy();
+  }));
+});

--- a/projects/player/src/app/rolling/rolling.guard.ts
+++ b/projects/player/src/app/rolling/rolling.guard.ts
@@ -1,0 +1,27 @@
+import {Injectable} from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  RouterStateSnapshot,
+  UrlTree
+} from '@angular/router';
+import {Observable} from 'rxjs';
+import {LoadStateService} from '../state/load/load-state-service.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RollingGuard implements CanActivate {
+
+  constructor(
+    private loadStateService: LoadStateService
+  ) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    return this.loadStateService.getLoadStateObservable();
+  }
+
+}

--- a/projects/player/src/app/rolling/rolling.module.ts
+++ b/projects/player/src/app/rolling/rolling.module.ts
@@ -7,13 +7,15 @@ import {
 } from '@angular/router';
 
 import {IonicModule} from '@ionic/angular';
+import {RollingGuard} from './rolling.guard';
 
 import {RollingPage} from './rolling.page';
 
 const routes: Routes = [
   {
     path: '',
-    component: RollingPage
+    component: RollingPage,
+    canActivate: [RollingGuard]
   }
 ];
 

--- a/projects/player/src/app/state/load/load-state-service.service.ts
+++ b/projects/player/src/app/state/load/load-state-service.service.ts
@@ -11,6 +11,7 @@ import {
 } from 'cr-lib';
 import {
   Observable,
+  ReplaySubject,
   Subject
 } from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
@@ -38,7 +39,7 @@ export class LoadStateService {
     private teamService: TeamService,
   ) {
     console.log('Hello LoadStateService');
-    this.loadStateSubject = new Subject<boolean>();
+    this.loadStateSubject = new ReplaySubject<boolean>(1);
     this.loadStateObservable = this.loadStateSubject.asObservable();
   }
 


### PR DESCRIPTION
- Adds `RollingGuard` to the Rolling page to make sure the Outing is
loaded before the code that builds the page will run.

Some work toward preparing the Profile; appears we want a guard for pages
that use the Profile too.