### PR TITLE
CI-102 Plop down the Team Assembled button

### DIFF
--- a/projects/player/src/app/app-routing.module.ts
+++ b/projects/player/src/app/app-routing.module.ts
@@ -20,7 +20,8 @@ const routes: Routes = [
     loadChildren: () => import('./list/list.module').then(m => m.ListPageModule)
   },
   { path: 'rolling', loadChildren: './rolling/rolling.module#RollingPageModule' },
-  { path: 'puzzle', loadChildren: './puzzle/puzzle.module#PuzzlePageModule' }
+  { path: 'puzzle', loadChildren: './puzzle/puzzle.module#PuzzlePageModule' },
+  { path: 'team', loadChildren: './team/team.module#TeamPageModule' }
 ];
 
 @NgModule({

--- a/projects/player/src/app/app.component.spec.ts
+++ b/projects/player/src/app/app.component.spec.ts
@@ -105,7 +105,7 @@ describe('AppComponent', () => {
     const menuItems = app.querySelectorAll('ion-label');
     expect(menuItems.length).toEqual(2);
     expect(menuItems[0].textContent).toContain('Home');
-    expect(menuItems[1].textContent).toContain('List');
+    expect(menuItems[1].textContent).toContain('Team');
   });
 
   it('should have urls', async () => {
@@ -115,7 +115,7 @@ describe('AppComponent', () => {
     const menuItems = app.querySelectorAll('ion-item');
     expect(menuItems.length).toEqual(2);
     expect(menuItems[0].getAttribute('ng-reflect-router-link')).toEqual('/home');
-    expect(menuItems[1].getAttribute('ng-reflect-router-link')).toEqual('/list');
+    expect(menuItems[1].getAttribute('ng-reflect-router-link')).toEqual('/team');
   });
 
 });

--- a/projects/player/src/app/app.component.ts
+++ b/projects/player/src/app/app.component.ts
@@ -24,9 +24,9 @@ export class AppComponent {
       icon: 'home'
     },
     {
-      title: 'List',
-      url: '/list',
-      icon: 'list'
+      title: 'Team',
+      url: '/team',
+      icon: 'contacts'
     }
   ];
 

--- a/projects/player/src/app/show-game/show-game.component.spec.ts
+++ b/projects/player/src/app/show-game/show-game.component.spec.ts
@@ -1,4 +1,3 @@
-import {HttpClient} from '@angular/common/http';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {
   async,
@@ -15,7 +14,6 @@ describe('ShowGameComponent', () => {
   let fixture: ComponentFixture<ShowGameComponent>;
 
   const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
-  const httpClientSpy = jasmine.createSpyObj('HttpClient', ['get']);
   const gameStateSpy = jasmine.createSpyObj('GameStateService', [
     'requestGameState',
     'getOutingState'
@@ -27,7 +25,6 @@ describe('ShowGameComponent', () => {
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
       providers: [
         ShowGameComponent,
-        {provide: HttpClient, useValue: httpClientSpy},
         {provide: GameStateService, useValue: gameStateSpy},
         {provide: Router, useValue: routerSpy},
       ]

--- a/projects/player/src/app/team/team.module.ts
+++ b/projects/player/src/app/team/team.module.ts
@@ -1,0 +1,31 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {
+  RouterModule,
+  Routes
+} from '@angular/router';
+
+import {IonicModule} from '@ionic/angular';
+import {MemberChipComponentModule} from 'cr-lib';
+
+import {TeamPage} from './team.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: TeamPage
+  }
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    MemberChipComponentModule,
+    RouterModule.forChild(routes)
+  ],
+  declarations: [TeamPage]
+})
+export class TeamPageModule {}

--- a/projects/player/src/app/team/team.page.html
+++ b/projects/player/src/app/team/team.page.html
@@ -1,0 +1,30 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Team</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ion-card>
+
+    <ion-card-header>Team Members for this Outing</ion-card-header>
+    <ion-card-content>
+
+      <ion-list *ngFor="let member of team.members">
+        <ion-item>
+          <cr-member-chip [member]="member">
+          </cr-member-chip>
+        </ion-item>
+      </ion-list>
+
+    </ion-card-content>
+  </ion-card>
+
+  <div *ngIf="canSignalTeamAssembled()">
+    <ion-fab horizontal="start" vertical="bottom">
+      <ion-fab-button size="small" (click)="signalTeamAssembled($event)">
+        <ion-icon name="add"></ion-icon>
+      </ion-fab-button>
+    </ion-fab>
+  </div>
+</ion-content>

--- a/projects/player/src/app/team/team.page.spec.ts
+++ b/projects/player/src/app/team/team.page.spec.ts
@@ -1,0 +1,41 @@
+import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
+import {
+  async,
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+import {GuideEventService} from '../state/guide-event.service';
+
+import {TeamPage} from './team.page';
+
+describe('TeamPage', () => {
+  let component: TeamPage;
+  let fixture: ComponentFixture<TeamPage>;
+
+  const guideEventSpy = jasmine.createSpyObj('GuideEventService', [
+    'isCurrentMemberGuide',
+    'signalTeamAssembled'
+  ]);
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TeamPage ],
+      providers: [
+        TeamPage,
+        {provide: GuideEventService, useValue: guideEventSpy},
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TeamPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/player/src/app/team/team.page.ts
+++ b/projects/player/src/app/team/team.page.ts
@@ -1,0 +1,41 @@
+import {
+  Component,
+  OnInit
+} from '@angular/core';
+import {Team} from 'cr-lib';
+import {GuideEventService} from '../state/guide-event.service';
+
+/**
+ * Presents the list of Team Members for the current outing.
+ */
+@Component({
+  selector: 'app-team',
+  templateUrl: './team.page.html',
+  styleUrls: ['./team.page.scss'],
+})
+export class TeamPage implements OnInit {
+
+  public team: Team;
+
+  constructor(
+    private guideEventService: GuideEventService
+  ) {
+    this.team = {
+      id: 1,
+      name: 'A-Team',
+      members: []
+    };
+  }
+
+  ngOnInit() {
+  }
+
+  public canSignalTeamAssembled(): boolean {
+    return this.guideEventService.isCurrentMemberGuide();
+  }
+
+  signalTeamAssembled() {
+    this.guideEventService.sendTeamAssembled();
+  }
+
+}


### PR DESCRIPTION
- Brings in TeamPage code and HTML from Ionic 3 app including the button.
- Patches in the spec code.

This also updates the show-game spec to not bother with defining the provider for HttpClient;
that code would only be brought in for services that talk to the back end.

If a spec asks for a provider of HttpClient, it could be because the spec
has gotten ahold of an actual service instead of a mocked service.