### PR TITLE
CI-111 Refresh of Map with filtered set of Attractions

### DIFF
--- a/projects/cr-lib/src/lib/api/location/location.service.ts
+++ b/projects/cr-lib/src/lib/api/location/location.service.ts
@@ -1,7 +1,10 @@
 import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs';
-import {AuthHeaderService, BASE_URL} from '../../auth/header/auth-header.service';
+import {
+  AuthHeaderService,
+  BASE_URL
+} from '../../auth/header/auth-header.service';
 import {LatLon} from '../../domain/lat-lon/lat-lon';
 import {Location} from './location';
 
@@ -65,6 +68,14 @@ export class LocationService {
       BASE_URL + 'location/featured?id=' + locationId,
       {headers: this.httpService.getAuthHeaders()}
     );
+  }
+
+  /* Currently, the filter is ignored; we're just hitting a specific course right now. */
+  getFilteredAttractions(attractionFilter: any): Observable<Location[]> {
+   return this.http.get<Location[]>(
+     BASE_URL + 'location/4/course',
+     {headers: this.httpService.getAuthHeaders()}
+   );
   }
 
 }

--- a/projects/ranger/src/app/map/action/map-action.component.ts
+++ b/projects/ranger/src/app/map/action/map-action.component.ts
@@ -72,7 +72,7 @@ export class MapActionComponent implements OnInit {
   toggleFilter(event: Event) {
     this.attractionsFilterFlag = !this.attractionsFilterFlag;
     console.log('Filter Attractions', this.attractionsFilterFlag);
-    // this.mapDataService.filterAttractions();
+    this.mapDataService.changeAttractionFilter(this.attractionsFilterFlag);
   }
 
 }

--- a/projects/ranger/src/app/map/data/map-data.service.ts
+++ b/projects/ranger/src/app/map/data/map-data.service.ts
@@ -32,6 +32,9 @@ export class MapDataService {
   private currentPosition: Geoposition;
   private currentPositionSubject: Subject<Geoposition> = new ReplaySubject<Geoposition>();
 
+  /* Function which responds to clear map events. */
+  private respondToClearMap: any;
+
   /* Our current Center of the map. */
   readonly reportedPosition: BehaviorSubject<Geoposition>;
 
@@ -207,6 +210,43 @@ export class MapDataService {
 
   public releaseWatch(): void {
     this.geoLoc.clearWatch();
+  }
+
+  /**
+   * Notification that we're ready to change to another filter for the Attractions.
+   *
+   * @param attractionFilter currently just a boolean, but expect that there will be details
+   * about the filter being applied so this service can retrieve the right set of records.
+   */
+  public changeAttractionFilter(attractionFilter: any): void {
+    if (this.respondToClearMap) {
+      this.respondToClearMap();
+    } else {
+      console.log('No response setup for clearing the map');
+    }
+
+    if (attractionFilter) {
+      this.locationService.getFilteredAttractions(attractionFilter).subscribe(
+        (attractions: Attraction[]) => {
+          from(attractions).subscribe(
+            (attraction: Attraction) => {
+              this.assembleAndAddAttraction(attraction);
+            }
+          );
+        }
+      );
+    } else {
+      this.resendAllLocations();
+    }
+  }
+
+  /**
+   * Assigns the function to call when the map needs to be cleared.
+   *
+   * @param clearMap function supplied by caller to perform the map clearing.
+   */
+  onMapClear(clearMap: any) {
+    this.respondToClearMap = clearMap;
   }
 
 }

--- a/projects/ranger/src/app/map/map.ts
+++ b/projects/ranger/src/app/map/map.ts
@@ -137,6 +137,7 @@ export class MapComponent {
 
     /* Begin paying attention to Attraction changes. */
     console.log('Map Component: subscribing to Attraction changes');
+    this.mapDataService.onMapClear(this.clearMap);
     this.subscription = this.mapDataService.sendMeNewAttractions(this.addAttraction);
     this.subscription.add(this.mapDataService.sendMeUpdatedAttractions(this.updateAttraction));
   }
@@ -196,7 +197,8 @@ export class MapComponent {
       iconName
     );
     // console.log('Adding ' + attraction.name + ' to the map');
-    /* TODO: Setting up the event can happen inside the service. */
+    /* TODO: Setting up the event can happen inside the service. Or can it? We have different destinations
+     *  for different apps. */
     poolMarker.on('click', (mouseEvent) => {
         this.openLocEditPageForMarkerClick(mouseEvent);
       });
@@ -207,6 +209,11 @@ export class MapComponent {
     this.layerIdPerAttraction[attraction.id] = this.layerPerCategory[DEFAULT_CATEGORY].getLayerId(poolMarker);
   }
 
+  /**
+   * Replace an existing Attraction with this new version of the same Attraction.
+   *
+   * @param attraction with updated information.
+   */
   updateAttraction = (
     attraction: Attraction
   ): void => {
@@ -238,6 +245,17 @@ export class MapComponent {
     }).catch( (error) => {
       console.log('Failed to launch edit page: ', error);
     });
+  }
+
+  /**
+   * Passed to Map Data Service whenever it determines that the map needs to be cleared in preparation for a new
+   * set of Attractions. This will eventually serve as the main Attraction layer for a focused set of Attractions.
+   *
+   * This is separate from the Category Group Layers discussed as part of ticket LE-76.
+   */
+  clearMap = (): void => {
+    // TODO: perhaps touched by LE-76
+    this.layerPerCategory[DEFAULT_CATEGORY].clearLayers();
   }
 
 }


### PR DESCRIPTION
- Adds callback for Map Data Service to tell map to clear the map.
- Amends Map Data Service to clear and then re-populate the map.
- Adds call to Location Service to hit the new Attractions by Course API.