### PR TITLE
CI-121 No menu on the Team Page

### DIFF
--- a/projects/player/src/app/team/team.page.html
+++ b/projects/player/src/app/team/team.page.html
@@ -1,5 +1,8 @@
 <ion-header>
   <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-menu-button></ion-menu-button>
+    </ion-buttons>
     <ion-title>Team</ion-title>
   </ion-toolbar>
 </ion-header>


### PR DESCRIPTION
- Adds menu to the Team page

(Button for recognizing the teams' presence is in place, but not available to
someone who is not the guide. May want multi-guide option here.