### PR TITLE
CI-130 Add User ID to SSE Open Connection calls

### DIFF
--- a/projects/cr-lib/src/lib/state/connection/connection-state.ts
+++ b/projects/cr-lib/src/lib/state/connection/connection-state.ts
@@ -16,20 +16,38 @@ export class ConnectionStateComponent {
   constructor(
     private serverEventsService: ServerEventsService
   ) {
-    console.log('Hello ConnectionStateComponent: Obtaining SSE EventSource');
-    this.eventSource = serverEventsService.getEventSource();
+    console.log('Hello ConnectionStateComponent: Requesting SSE EventSource');
+    serverEventsService.getEventSource().subscribe(
+      (eventSource) => this.eventSource = eventSource
+    );
   }
 
+  /**
+   * This is used to tell if we've yet received the EventSource Polyfill.
+   */
+  public haveEventSource(): boolean {
+    return !!this.eventSource;
+  }
+
+  /**
+   * True if the current SSE event channel is open.
+   */
   public isOpen(): boolean {
-    return this.eventSource.readyState === this.eventSource.OPEN;
+    return this.haveEventSource() && this.eventSource.readyState === this.eventSource.OPEN;
   }
 
+  /**
+   * True if the current SSE event channel is attempting to reconnect.
+   */
   public isConnecting(): boolean {
-    return this.eventSource.readyState === this.eventSource.CONNECTING;
+    return this.haveEventSource() && this.eventSource.readyState === this.eventSource.CONNECTING;
   }
 
+  /**
+   * True if the current SSE event channel is closed or not yet opened.
+   */
   public isClosed(): boolean {
-    return this.eventSource.readyState === this.eventSource.CLOSED;
+    return !this.haveEventSource() || this.eventSource.readyState === this.eventSource.CLOSED;
   }
 
 }


### PR DESCRIPTION
- Adds the BadgeOS ID to the URL for opening the SSE connection.
- Changes how the Connection State component picks up its copy of the
EventSourcePolyfill. It no longer drives when the call to establish the
SSE connection is made, and instead, waits for it to be handed the one
that is opened by other clients.

Related to CI-126.