### PR TITLE
CI-120 Map empty after returning to home page via menu

### DIFF
--- a/projects/player/src/app/rolling/rolling.page.ts
+++ b/projects/player/src/app/rolling/rolling.page.ts
@@ -215,4 +215,9 @@ export class RollingPage {
     this.guideEventService.sendArrival();
   }
 
+  ngOnDestroy() {
+    console.log('Rolling page does get destroyed.');
+    RollingPage.map = null;
+  }
+
 }


### PR DESCRIPTION
- The page was being destroyed along with the map, but there was no
record of that destruction -- the map instance was still non-null.