### PR TITLE
CI-143 2nd session against an outing doesn't open to the right page

### DIFF
--- a/projects/player/src/app/app.component.spec.ts
+++ b/projects/player/src/app/app.component.spec.ts
@@ -17,7 +17,6 @@ import {
 import {of} from 'rxjs';
 
 import {AppComponent} from './app.component';
-import {SummaryComponentsModule} from './components.module';
 import {AppStateService} from './state/app/app-state.service';
 import {LoadStateService} from './state/load/load-state.service';
 
@@ -83,8 +82,7 @@ describe('AppComponent', () => {
         { provide: SplashScreen, useValue: splashScreenSpy },
       ],
       imports: [
-        RouterTestingModule.withRoutes([]),
-        SummaryComponentsModule.forRoot()
+        RouterTestingModule.withRoutes([])
       ],
     }).compileComponents();
   }));

--- a/projects/player/src/app/rolling/rolling.page.ts
+++ b/projects/player/src/app/rolling/rolling.page.ts
@@ -64,6 +64,7 @@ export class RollingPage {
   ) {
     /* Initialize GameState here to make sure we are caught up with current state as we join in. */
     /* This should pull from a ReplaySubject that holds just the last GameState; don't care how that gets populated. */
+    // TODO: CI-143
     this.gameStateService.requestGameState()
       .subscribe(
         (gameState) => {

--- a/projects/player/src/app/show-game/show-game.component.ts
+++ b/projects/player/src/app/show-game/show-game.component.ts
@@ -17,7 +17,7 @@ export class ShowGameComponent {
   ) { }
 
   public showGame(): void {
-    // TODO: This probably could be either a) synchronous or b) pulled from a ReplaySubject.
+    // TODO: CI-143 This probably could be either a) synchronous or b) pulled from a ReplaySubject.
     this.gameStateService.requestGameState()
       .pipe(
         take(1)

--- a/projects/player/src/app/state/game/game-state.service.spec.ts
+++ b/projects/player/src/app/state/game/game-state.service.spec.ts
@@ -1,36 +1,158 @@
-import {HttpClient} from '@angular/common/http';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+  TestRequest
+} from '@angular/common/http/testing';
 import {TestBed} from '@angular/core/testing';
 import {
   AuthHeaderService,
+  BASE_URL,
   ServerEventsService
 } from 'cr-lib';
 import {of} from 'rxjs';
+import {GameState} from './game-state';
+import {GameStateMock} from './game-state.mock';
 
 import {GameStateService} from './game-state.service';
 
-const authHeaderSpy = jasmine.createSpyObj('AuthHeaderService', ['headers']);
-const httpClientSpy = jasmine.createSpyObj('HttpClient', ['get']);
+const authHeaderSpy = jasmine.createSpyObj('AuthHeaderService', ['getAuthHeaders']);
+// const httpClientSpy = jasmine.createSpyObj('HttpClient', ['get']);
 const sseSpy = jasmine.createSpyObj('ServerEventsService', ['getGameStateEventObservable']);
 
 let getGameStateObservableSpy;
 
 describe('GameStateService', () => {
+  let toTest: GameStateService,
+    httpMock: HttpTestingController,
+    gameStateMock: GameStateMock;
+
   beforeEach( () => {
     getGameStateObservableSpy = sseSpy.getGameStateEventObservable.and.returnValue(of({}));
 
     TestBed.configureTestingModule({
       providers: [
         GameStateService,
+        GameStateMock,
         {provide: AuthHeaderService, useValue: authHeaderSpy},
-        {provide: HttpClient, useValue: httpClientSpy},
         {provide: ServerEventsService, useValue: sseSpy},
+      ],
+      imports: [
+        HttpClientTestingModule
       ]
     });
+
+    toTest = TestBed.get(GameStateService);
+    httpMock = TestBed.get(HttpTestingController);
+    gameStateMock = TestBed.get(GameStateMock);
   });
 
   it('should be created', () => {
-    const service: GameStateService = TestBed.get(GameStateService);
-    expect(service).toBeTruthy();
+    expect(toTest).toBeTruthy();
+  });
+
+  describe('getGameState', () => {
+
+    it('should be exposed on the service', () => {
+      expect(toTest.getGameState).toBeDefined();
+    });
+
+    it('should block until a Game State event becomes available', () => {
+      /* setup data */
+      let gotGameState = false;
+
+      /* make call */
+      toTest.getGameState().subscribe(
+        (gameState) => {
+          gotGameState = true;
+        }
+      );
+
+      /* verify results */
+      expect(gotGameState).toBeFalsy();
+    });
+
+    it('should return fully-populated game state if it is already available', () => {
+      /* setup data */
+      let actual: GameState;
+      const expected: GameState = gameStateMock.generateInitialMock();
+
+      /* Inserts a Game State as if it came from SSE. */
+      toTest.updateFromSSE({
+        event: 'Testing',
+        gameState: expected
+      });
+
+      /* make call */
+      toTest.getGameState().subscribe(
+        (gameState) => {
+          actual = gameState;
+        }
+      );
+
+      /* verify results */
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return fully-populated game state if it becomes available', () => {
+      /* setup data */
+      let actual: GameState;
+      const expected: GameState = gameStateMock.generateInitialMock();
+
+      /* make call */
+      toTest.getGameState().subscribe(
+        (gameState) => {
+          actual = gameState;
+        }
+      );
+
+      /* Inserts a Game State as if it came from SSE. */
+      toTest.updateFromSSE({
+        event: 'Testing',
+        gameState: expected
+      });
+
+      /* verify results */
+      expect(actual).toEqual(expected);
+    });
+
+  });
+
+  describe('requestGameState', () => {
+
+    it('should be defined', () => {
+      expect(toTest.requestGameState).toBeDefined();
+    });
+
+    it('should make no Game State calls to back-end if not requested', () => {
+      httpMock.expectNone(BASE_URL + 'game-state');
+      httpMock.verify();
+    });
+
+    it('should make exactly one call to back-end when requested', () => {
+      /* make call */
+      toTest.requestGameState();
+
+      const gameStateRequest: TestRequest = httpMock.expectOne(BASE_URL + 'game-state');
+      gameStateRequest.flush(gameStateMock.generateInitialMock());
+
+      /* verify results */
+      expect(authHeaderSpy.getAuthHeaders).toHaveBeenCalled();
+      httpMock.verify();
+    });
+
+    it('should make no further calls to back-end if this call is made more than once', () => {
+      /* make call */
+      toTest.requestGameState();
+      toTest.requestGameState();
+
+      const gameStateRequest: TestRequest = httpMock.expectOne(BASE_URL + 'game-state');
+      gameStateRequest.flush(gameStateMock.generateInitialMock());
+
+      /* verify results */
+      expect(authHeaderSpy.getAuthHeaders).toHaveBeenCalled();
+      httpMock.verify();
+    });
+
   });
 
 });

--- a/projects/player/src/app/state/load/load-state.service.ts
+++ b/projects/player/src/app/state/load/load-state.service.ts
@@ -129,6 +129,7 @@ export class LoadStateService {
   private loadGameState() {
     /* This service doesn't use the game state.
      * It only makes sure the server has game state available before proceeding. */
+    // TODO: CI-143, this could be the single appropriate place to kick-off a read from the server regarding game-state.
     this.gameStateService.requestGameState()
       .pipe(
         takeUntil(this.loadStateObservable)


### PR DESCRIPTION
- Adds guard to the `requestGameState` call to prevent multiple requests
to the backend.