### PR TITLE
filter-page-odds-and-ends

### DIFF
--- a/projects/cr-lib/src/lib/api/attraction/layer/attraction-layer.service.ts
+++ b/projects/cr-lib/src/lib/api/attraction/layer/attraction-layer.service.ts
@@ -85,9 +85,10 @@ export class AttractionLayerService {
    */
   showFilteredAttractions(filter: Filter): void {
     if (!this.mapWithLayers) {
-      throw new Error(
+      console.log(
         'Map not yet provided; call `loadAttractionLayers()` first'
       )
+      return;
     }
 
     const existingLayers = this.mapWithLayers.getLayers();

--- a/projects/ranger/src/app/filter/filter.page.html
+++ b/projects/ranger/src/app/filter/filter.page.html
@@ -19,7 +19,8 @@
       by Course
     </ion-card-title>
     <ion-card-content>
-      <ion-select
+      <ion-select placeholder="No Courses included"
+                  interface="alert"
                   multiple="true"
                   okText="Okay"
                   cancelText="Nah">
@@ -36,6 +37,9 @@
     </ion-card-title>
     <ion-card-content>
       <ion-select (ionChange)="categoryHasChanged($event)"
+                  placeholder="No Categories included"
+                  interface="alert"
+                  [interfaceOptions]="categoryAlertOptions"
                   multiple="true"
                   okText="Okay"
                   cancelText="Nah">

--- a/projects/ranger/src/app/filter/filter.page.ts
+++ b/projects/ranger/src/app/filter/filter.page.ts
@@ -21,7 +21,12 @@ export class FilterPage implements OnInit {
   public courses: Course[];
   public categories: Category[];
 
-  private filter: Filter;
+  /* Passing CSS to the popover. */
+  public categoryAlertOptions: any = {
+    cssClass: "category-alert"
+  };
+
+  private readonly filter: Filter;
 
   constructor(
     private courseService: CourseService,

--- a/projects/ranger/src/theme/variables.scss
+++ b/projects/ranger/src/theme/variables.scss
@@ -83,3 +83,8 @@ ion-content {
 .cr-card {
   --background: white;
 }
+
+/* Allows all of the choices to be viewed at once. */
+.category-alert .alert-checkbox-group {
+  max-height: none;
+}


### PR DESCRIPTION
- Overrides styling of the category choices to allow full set of choices to be presented.
- Provides placeholder text to indicate what might be done.
- Removes annoying alert when the map hasn't been added and turns it into a console message.