### PR TITLE
CI-159: explore-broken-ranger-map

### DIFF
--- a/projects/cr-lib/src/lib/api/attraction/category/category-attraction.service.ts
+++ b/projects/cr-lib/src/lib/api/attraction/category/category-attraction.service.ts
@@ -1,6 +1,5 @@
 import {Injectable} from '@angular/core';
 import {
-  from,
   Observable,
   Subject
 } from 'rxjs';
@@ -52,7 +51,8 @@ export class CategoryAttractionService {
   }
 
   buildCategoryMap(allAttractions: Attraction[]): void {
-    from(allAttractions).subscribe(
+    /* This should be synchronous to make sure we've built everything before returning. */
+    allAttractions.forEach(
       (attraction) => {
         attraction.locationType = this.locTypeService.getById((attraction.locationTypeId));
 

--- a/projects/cr-lib/src/lib/api/attraction/layer/attraction-layer.service.ts
+++ b/projects/cr-lib/src/lib/api/attraction/layer/attraction-layer.service.ts
@@ -11,21 +11,29 @@ import {PoolMarkerService} from '../../../marker/pool/pool-marker.service';
 import {CategoryService} from '../../category/category.service';
 import {AttractionsByCategory} from '../category/attractions-by-category';
 import {CategoryAttractionService} from '../category/category-attraction.service';
+import {Category} from '../../category/category';
+import {Attraction} from '../attraction';
 
 interface LayerPerCategory {
   [index: number]: L.Layer;
 }
 
+/**
+ * Responsible for the Layers of Attractions that are placed on the Map.
+ *
+ * It is called when data is loaded, and updated when changes are made.
+ *
+ * It collaborates with the MapDataService and the Filter to provide
+ * ready-to-go layers to turn on/off on the map.
+ */
 @Injectable({
   providedIn: 'root'
 })
 export class AttractionLayerService {
 
   private attractionLayerSubject: Subject<boolean>;
-  /* Maps a given Category ID to the Layer which holds the Category's attractions; readonly to allow testing. */
-  readonly layerPerCategory: LayerPerCategory = {};
-
-  private mapWithLayers: L.Map;
+  /* Maps a given Category ID to the Layer which holds the Category's attractions. */
+  private layerPerCategory: LayerPerCategory;
 
   constructor(
     private categoryService: CategoryService,
@@ -38,41 +46,60 @@ export class AttractionLayerService {
   /**
    * Trigger for when we can load the cache for Attraction Layers.
    */
-  loadAttractionLayers(map: L.Map): Observable<boolean> {
-    if (!map) {
-      throw new Error('Map cannot be empty');
-    }
-    if (this.mapWithLayers) {
-      console.log('Layers have already been initialized (and the map too)');
-      return this.attractionLayerSubject.asObservable();
-    }
-    this.mapWithLayers = map;
-    this.mapWithLayers.clearLayers();
+  loadAttractionLayers(): Observable<boolean> {
+    if (this.layerPerCategory) {
+      console.log('Layers have already been initialized');
+    } else {
+      console.log('AttractionLayerService.loadAttractionLayers()');
 
-    /* Map itself is in place; now pickup the Attractions. */
-    const attractionsByCategory: AttractionsByCategory = this.categoryAttractionService.getAttractionMap();
+      this.layerPerCategory = {};
 
-    for (const categoryId in attractionsByCategory) {
-      if (attractionsByCategory.hasOwnProperty(categoryId)) {
-        const attractionsList = attractionsByCategory[categoryId];
-        console.log('Category ' + categoryId + ' has ' + attractionsList.length + ' entries');
-        this.layerPerCategory[categoryId] = L.layerGroup().addTo(this.mapWithLayers);
-
-        // TODO CI-160
-        /* This creates editable markers; want a different set for display-only. */
-        attractionsList.forEach(
-          (attraction) => {
-            const marker: ClickableMarker = this.poolMarkerService.getAttractionMarker(attraction);
-            this.layerPerCategory[categoryId].addLayer(marker);
-          }
-        );
-
+      /* Populate the Categories, if needed. */
+      if (this.categoryService.getAllCategories().length == 0) {
+        this.categoryService.loadSync();
       }
+
+      this.categoryService.getAllCategories().forEach(
+        (category: Category) => {
+          console.log('AttractionLayerService.constructor()', category.name);
+          this.layerPerCategory[category.id] = new L.LayerGroup();
+        }
+      );
+
+      /* AttractionLayers don't make any sense until we've got the Categories. */
+      this.categoryAttractionService.loadAllAttractions().subscribe(
+        () => {
+          const attractionsByCategory: AttractionsByCategory = this.categoryAttractionService.getAttractionMap();
+
+          for (const categoryId in attractionsByCategory) {
+            if (attractionsByCategory.hasOwnProperty(categoryId)) {
+              const attractionsList = attractionsByCategory[categoryId];
+              console.log('Category ' + categoryId + ' has ' + attractionsList.length + ' entries');
+
+              attractionsList.forEach(
+                (attraction) => {
+                  this.addAttractionToLayer(attraction, categoryId);
+                }
+              );
+            }
+          }
+          this.attractionLayerSubject.next(true);
+        }
+      );
+
     }
-
-    this.attractionLayerSubject.next(true);
-
     return this.attractionLayerSubject.asObservable();
+  }
+
+  private addAttractionToLayer(attraction: Attraction, categoryId: string) {
+    // TODO CI-160
+    /* This creates editable markers; want a different set for display-only. */
+    if (attraction.locationType) {
+      const marker: ClickableMarker = this.poolMarkerService.getAttractionMarker(attraction);
+      this.layerPerCategory[categoryId].addLayer(marker);
+    } else {
+      console.log('AttractionLayerService: no Location Type for ', attraction.name);
+    }
   }
 
   /**
@@ -81,36 +108,56 @@ export class AttractionLayerService {
    * Algorithm is to review list of all Categories against what is currently on or off, and decide
    * if a change needs to be made to that Category, either turning it on or turning it off.
    *
-   * @param filter
+   * @param filter tells us what Categories and Courses should be included.
+   * @param map is where we're putting the layers.
    */
-  showFilteredAttractions(filter: Filter): void {
-    if (!this.mapWithLayers) {
-      console.log(
-        'Map not yet provided; call `loadAttractionLayers()` first'
-      )
+  showFilteredAttractions(
+    filter: Filter,
+    map: L.Map
+  ): void {
+    /* Problem if we call this without providing the map. */
+    if (!map) {
+      console.log('Map not provided');
       return;
     }
 
-    const existingLayers = this.mapWithLayers.getLayers();
-    this.categoryService.getAllCategories().forEach(
-      (category) => {
-        console.log('Checking category ID ' + category.id);
+    console.log('showFilteredAttractions: # of Categories:', this.categoryService.getAllCategories().length);
 
-        /* Only toggle the layer if we have markers for the category. */
-        if (this.layerPerCategory[category.id]) {
-          const layerTurnedOn = existingLayers.includes(this.layerPerCategory[category.id]);
-          const filterTurnedOn = filter.categoriesToIncludeById.includes(category.id);
-          if (layerTurnedOn != filterTurnedOn) {
-            if (filterTurnedOn) {
-              this.mapWithLayers.addLayer(this.layerPerCategory[category.id]);
-            } else {
-              this.mapWithLayers.removeLayer(this.layerPerCategory[category.id]);
+    if (filter.isEmpty) {
+      /* Place all categories on the map. */
+      map.clearLayers();
+      this.categoryService.getAllCategories().forEach(
+        (category: Category) => {
+          map.addLayer(this.layerPerCategory[category.id]);
+        }
+      );
+    } else {
+
+      const existingLayers = map.getLayers();
+      this.categoryService.getAllCategories().forEach(
+        (category) => {
+          console.log('Checking category ID ' + category.id);
+
+          /* Only toggle the layer if we have markers for the category. */
+          if (this.layerPerCategory[category.id] && this.layerPerCategory[category.id].getLayers().length > 0) {
+            const layerTurnedOn = !!existingLayers.includes(this.layerPerCategory[category.id]);
+            const filterTurnedOn = !!filter.categoriesToIncludeById.includes(category.id);
+            if (layerTurnedOn !== filterTurnedOn) {
+              if (filterTurnedOn) {
+                console.log('Including category', category.name);
+                map.addLayer(this.layerPerCategory[category.id]);
+              } else {
+                console.log('Removing category', category.name);
+                map.removeLayer(this.layerPerCategory[category.id]);
+              }
             }
+          } else {
+            console.log('No markers for Category', category.name);
           }
         }
-      }
-    );
+      );
 
+    }
   }
 
 }

--- a/projects/cr-lib/src/lib/api/category/category.service.ts
+++ b/projects/cr-lib/src/lib/api/category/category.service.ts
@@ -22,16 +22,20 @@ export class CategoryService {
     private authHeaderService: AuthHeaderService
   ) {
     console.log('Hello CategoryService');
-    this.http.get<Category[]>(
+    this.loadSync();
+  }
+
+  public async loadSync() {
+    await this.http.get<Category[]>(
       BASE_URL + 'category',
       {headers: this.authHeaderService.getAuthHeaders()}
     ).subscribe(
-      (response) =>  {
+      (response) => {
         response.forEach(category => {
           this.categories.push(category);
           this.categoriesById[category.id] = category;
         });
-        console.log('Loc Type Cache filled. total: ' + this.categories.length);
+        console.log('Category Cache filled. total: ' + this.categories.length);
       }
     );
   }

--- a/projects/cr-lib/src/lib/auth/token/token.service.ts
+++ b/projects/cr-lib/src/lib/auth/token/token.service.ts
@@ -20,6 +20,7 @@ export class TokenService {
 
   constructor(
   ) {
+    console.log('Hello TokenService');
     this.payload = JSON.parse(
       window.localStorage.getItem(STORAGE_KEYS.profile)
     );

--- a/projects/cr-lib/src/lib/badge-award/badge-award.component.ts
+++ b/projects/cr-lib/src/lib/badge-award/badge-award.component.ts
@@ -1,8 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import {
+  Component,
+  OnInit
+} from '@angular/core';
 import {
   NavParams,
   PopoverController
-} from "@ionic/angular";
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-badge-award',
@@ -28,6 +31,5 @@ export class BadgeAwardComponent implements OnInit {
     this.popoverController.dismiss();
   }
 
-  // TODO: I may want a separate AppState that talks about shutting down the entire app
-  // and we would listen to that to know when to stop subscribing.
+  // TODO: Shutting down should pay attention to the Platform signals.
 }

--- a/projects/cr-lib/src/lib/filter/filter.service.ts
+++ b/projects/cr-lib/src/lib/filter/filter.service.ts
@@ -1,16 +1,35 @@
 import {Injectable} from '@angular/core';
+import {Filter} from './filter';
+import {
+  Observable,
+  ReplaySubject,
+  Subject
+} from 'rxjs';
 
 /**
  * Associated with the on/off button style of filter used as a POC;
  * that button has been rendered obsolete by the FilterPage.
+ *
+ * Also keeps track of the current value for the Filter.
  */
 @Injectable({
   providedIn: 'root'
 })
 export class FilterService {
   private filterShown: boolean;
+  private currentFilter: Filter;
 
-  constructor() { }
+  /* Publish changes to the Filter on this Subject. */
+  private readonly filterSubject: Subject<Filter>;
+
+  constructor() {
+    this.filterSubject = new ReplaySubject<Filter>();
+    this.currentFilter = {
+      categoriesToIncludeById: [],
+      outingToInclude: null,
+      isEmpty: true
+    };
+  }
 
   /**
    * Returns current state of whether the filter is turned on or not.
@@ -25,6 +44,22 @@ export class FilterService {
   public toggleFilterShown(): boolean {
     this.filterShown = !this.filterShown;
     return  this.filterShown;
+  }
+
+  public changeFilter(filter: Filter) {
+    this.currentFilter = filter;
+    this.filterSubject.next(filter);
+  }
+
+  public getCurrentFilter(): Filter {
+    return this.currentFilter;
+  }
+
+  /**
+   * Listen for filter changes by subscribing to this Observable.
+   */
+  public getFilterObservable(): Observable<Filter> {
+    return this.filterSubject.asObservable();
   }
 
 }

--- a/projects/cr-lib/src/lib/filter/filter.ts
+++ b/projects/cr-lib/src/lib/filter/filter.ts
@@ -4,12 +4,13 @@
  * Prepared by FilterPage (or a similar dialog/popover) and consumed by AttractionLayerService
  * which is responsible for adding them to the map.
  *
- * An empty filter (the default which is initialized below) means to show nothing.
- * A filter that isn't supplied -- or a null filter -- means show everything.
+ * An empty filter (the default which is initialized below) means to show everything.
+ * A filter that isn't supplied -- or a null filter -- also means show everything.
  */
 
 /** Default is to include nothing. */
 export class Filter {
   categoriesToIncludeById: number[] = [];
   outingToInclude: number = null;
+  isEmpty: boolean = true;
 }

--- a/projects/cr-lib/src/lib/geo/geo-loc/geo-loc.spec.ts
+++ b/projects/cr-lib/src/lib/geo/geo-loc/geo-loc.spec.ts
@@ -42,7 +42,7 @@ describe('Geo-Location', () => {
       /* setup data */
       let actual: Geoposition;
       const serviceReadySubject: Subject<Geoposition> = new Subject();
-      const expected = GeoLocService.DEFAULT_GEOPOSITION;
+      const expected = GeoLocService.ATLANTA_GEOPOSITION;
 
       /* train mocks */
       spyOn(deviceGeoLocService, 'checkGpsAvailability').and.returnValue(serviceReadySubject.asObservable());
@@ -221,7 +221,7 @@ describe('Geo-Location', () => {
     it('should return default position when GPS not available', () => {
       /* setup data */
       let actual: any;
-      const expected = GeoLocService.DEFAULT_GEOPOSITION;
+      const expected = GeoLocService.ATLANTA_GEOPOSITION;
       const positionSubject: Subject<any> = new Subject();
 
       /* train mocks */
@@ -246,7 +246,7 @@ describe('Geo-Location', () => {
     it('should return default position when device returns null', () => {
       /* setup data */
       let actual: any;
-      const expected = GeoLocService.DEFAULT_GEOPOSITION;
+      const expected = GeoLocService.ATLANTA_GEOPOSITION;
       const positionSubject: Subject<any> = new Subject();
 
       /* train mocks */

--- a/projects/cr-lib/src/lib/geo/geo-loc/geo-loc.ts
+++ b/projects/cr-lib/src/lib/geo/geo-loc/geo-loc.ts
@@ -1,6 +1,10 @@
 import {Injectable} from '@angular/core';
 import {Geoposition} from '@ionic-native/geolocation';
-import {Observable, Subject} from 'rxjs';
+import {
+  Observable,
+  ReplaySubject,
+  Subject
+} from 'rxjs';
 import {DeviceGeoLocService} from '../device-geo-loc/device-geo-loc.service';
 
 @Injectable({
@@ -8,10 +12,10 @@ import {DeviceGeoLocService} from '../device-geo-loc/device-geo-loc.service';
 })
 export class GeoLocService {
 
-  static DEFAULT_GEOPOSITION: Geoposition = {
+  public static readonly ATLANTA_GEOPOSITION: Geoposition = {
     coords: {
-      latitude: 33.76,
-      longitude: -84.38,
+      latitude: 33.753,
+      longitude: -84.390,
       accuracy: 0.0,
       altitude: null,
       altitudeAccuracy: null,
@@ -43,7 +47,7 @@ export class GeoLocService {
    * will provide an async response once the checks are completed and
    * this service is ready for use.
    *
-   * @returns ObservableGeoposition which represents our position whether
+   * @returns Observable of Geoposition which represents our position whether
    * it comes from this device's GPS or from a Tethered position (or another source).
    */
   public notifyWhenReady(): Observable<Geoposition> {
@@ -53,11 +57,11 @@ export class GeoLocService {
         if (response) {
           serviceReady.next(response);
         } else {
-          serviceReady.next(GeoLocService.DEFAULT_GEOPOSITION);
+          serviceReady.next(GeoLocService.ATLANTA_GEOPOSITION);
         }
       },
       () => {
-        serviceReady.next(GeoLocService.DEFAULT_GEOPOSITION);
+        serviceReady.next(GeoLocService.ATLANTA_GEOPOSITION);
       }
     );
     return serviceReady.asObservable();
@@ -114,7 +118,7 @@ export class GeoLocService {
 
   private getTetheredPosition(): Observable<Geoposition> {
     if (!this.tetheredFlag) {
-      this.tetheredPosition = new Subject();
+      this.tetheredPosition = new ReplaySubject();
       this.keepScheduling = true;
       this.tetheredFlag = true;
       this.startMonitoringTether();
@@ -123,6 +127,9 @@ export class GeoLocService {
   }
 
   private startMonitoringTether(): void {
+    // Temporary until we get another position source.
+    this.tetheredPosition.next(GeoLocService.ATLANTA_GEOPOSITION);
+
     // TODO: FEC-47 Replace this with the SSE Tether service.
     // let monitorPromise = this.restangular.one("tether/dev").get().toPromise();
     // monitorPromise.then(

--- a/projects/cr-lib/src/lib/marker/README.md
+++ b/projects/cr-lib/src/lib/marker/README.md
@@ -14,7 +14,7 @@ the resources is part of the environment and project setup.)
 * The build tools assure the resources (images and CSS) are
 copied to the right locations.
 
-# Approach
+# Setup
 
 * The JavaScript files which support Leaflet are intended to be 
 used across a broad range of browser-based applications.

--- a/projects/cr-lib/src/lib/marker/pool/pool-marker.service.ts
+++ b/projects/cr-lib/src/lib/marker/pool/pool-marker.service.ts
@@ -56,7 +56,7 @@ export class PoolMarkerService {
     /* Icon comes from the IconService. */
     const poolIcon: L.AwesomeMarkers.Icon = this.iconService.getPoolMarkerIcon(
       attraction.readinessLevel,
-      attraction.locationTypeIconName
+      attraction.locationType.icon
     );
 
     /* Options assembled from icon and the attraction. */

--- a/projects/player/src/app/state/app/app-state.service.ts
+++ b/projects/player/src/app/state/app/app-state.service.ts
@@ -29,7 +29,7 @@ export class AppStateService {
   }
 
   /**
-   * Based on the inbound AppState, transition to the next state.
+   * Based on the inbound RangerAppState, transition to the next state.
    *
    * NOTE: This is similar to the approach taken for GameState, but
    * there may be existing routing and state code from Angular to

--- a/projects/ranger/src/app/app-state/ranger-app-state.ts
+++ b/projects/ranger/src/app/app-state/ranger-app-state.ts
@@ -1,7 +1,7 @@
 import {PositionSourceType} from 'cr-lib';
 
 /** Defines the items that show up on the Status Page. */
-export class AppState {
+export class RangerAppState {
   registeredAs = ' ... ';
   registrationState = '';
   isRunningBrowser = true;
@@ -9,5 +9,6 @@ export class AppState {
   cacheState = ' ... ';
   locationCount = 0;
   readyToEdit = false;
+  readyToOpen = false;
 }
 

--- a/projects/ranger/src/app/app.component.spec.ts
+++ b/projects/ranger/src/app/app.component.spec.ts
@@ -13,7 +13,7 @@ import {
   PlatformStateService
 } from 'cr-lib';
 import {of} from 'rxjs';
-import {AppStateService} from './app-state/app-state.service';
+import {RangerAppStateService} from './app-state/ranger-app-state.service';
 
 import {AppComponent} from './app.component';
 
@@ -39,7 +39,7 @@ describe('AppComponent', () => {
       declarations: [AppComponent],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
       providers: [
-        { provide: AppStateService, useValue: appStateSpy },
+        { provide: RangerAppStateService, useValue: appStateSpy },
         { provide: AwaitRegistrationService, useValue: authClient },
         { provide: StatusBar, useValue: statusBarSpy },
         { provide: SplashScreen, useValue: splashScreenSpy },

--- a/projects/ranger/src/app/app.component.ts
+++ b/projects/ranger/src/app/app.component.ts
@@ -7,7 +7,7 @@ import {
   AwaitRegistrationService,
   PlatformStateService
 } from 'cr-lib';
-import {AppStateService} from './app-state/app-state.service';
+import {RangerAppStateService} from './app-state/ranger-app-state.service';
 
 @Component({
   selector: 'app-root',
@@ -40,7 +40,7 @@ export class AppComponent {
 
   constructor(
     private authClient: AwaitRegistrationService,
-    private appStateService: AppStateService,
+    private appStateService: RangerAppStateService,
     private platform: Platform,
     private platformStateService: PlatformStateService,
     private splashScreen: SplashScreen,

--- a/projects/ranger/src/app/filter/filter.page.ts
+++ b/projects/ranger/src/app/filter/filter.page.ts
@@ -3,12 +3,12 @@ import {
   OnInit
 } from '@angular/core';
 import {
-  AttractionLayerService,
   Category,
   CategoryService,
   Course,
   CourseService,
-  Filter
+  Filter,
+  FilterService
 } from 'cr-lib';
 
 @Component({
@@ -31,10 +31,10 @@ export class FilterPage implements OnInit {
   constructor(
     private courseService: CourseService,
     private categoryService: CategoryService,
-    private attractionLayerService: AttractionLayerService,
+    private filterService: FilterService,
   ) {
     this.categories = [];
-    this.filter = new Filter();
+    this.filter = filterService.getCurrentFilter();
   }
 
   ngOnInit() {
@@ -50,7 +50,17 @@ export class FilterPage implements OnInit {
   categoryHasChanged(event: CustomEvent) {
     console.log(event);
     this.filter.categoriesToIncludeById = event.detail.value;
-    this.attractionLayerService.showFilteredAttractions(this.filter);
+    this.filter.isEmpty = this.checkIfFilterEmpty();
+    this.filterService.changeFilter(this.filter);
+  }
+
+  // TODO: Add Course changes here too.
+
+  checkIfFilterEmpty(): boolean {
+    return (
+      this.filter.categoriesToIncludeById.length === 0 &&
+      this.filter.outingToInclude != null
+    );
   }
 
 }

--- a/projects/ranger/src/app/home/home.guard.spec.ts
+++ b/projects/ranger/src/app/home/home.guard.spec.ts
@@ -1,0 +1,25 @@
+import {
+  inject,
+  TestBed
+} from '@angular/core/testing';
+import {AwaitRegistrationService} from 'cr-lib';
+
+import {HomeGuard} from './home.guard';
+
+const awaitRegistrationSpy = jasmine.createSpyObj('AwaitRegistrationService', ['getRegistrationActiveObservable']);
+
+describe('HomeGuard', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        HomeGuard,
+        {provide: AwaitRegistrationService, useValue: awaitRegistrationSpy},
+      ]
+    });
+  });
+
+  it('should be created', inject([HomeGuard], (guard: HomeGuard) => {
+    expect(guard).toBeTruthy();
+  }));
+
+});

--- a/projects/ranger/src/app/home/home.guard.ts
+++ b/projects/ranger/src/app/home/home.guard.ts
@@ -5,8 +5,8 @@ import {
   RouterStateSnapshot,
   UrlTree
 } from '@angular/router';
-import {AwaitRegistrationService} from 'cr-lib';
 import {Observable} from 'rxjs';
+import {RangerAppStateService} from '../app-state/ranger-app-state.service';
 
 @Injectable({
   providedIn: 'root'
@@ -14,14 +14,14 @@ import {Observable} from 'rxjs';
 export class HomeGuard implements CanActivate {
 
   constructor(
-    private awaitRegistrationService: AwaitRegistrationService,
+    private rangerAppStateService: RangerAppStateService,
   ) {}
 
   canActivate(
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
-    return this.awaitRegistrationService.getRegistrationActiveObservable('com.clueride.player');
+    return this.rangerAppStateService.isAppReadyToOpen();
   }
 
 }

--- a/projects/ranger/src/app/home/home.module.ts
+++ b/projects/ranger/src/app/home/home.module.ts
@@ -7,6 +7,7 @@ import {ConnectionStateModule} from 'cr-lib';
 import {MapModule} from '../map/map.module';
 
 import {HomePage} from './home.page';
+import {HomeGuard} from './home.guard';
 
 @NgModule({
   imports: [
@@ -18,7 +19,8 @@ import {HomePage} from './home.page';
     RouterModule.forChild([
       {
         path: '',
-        component: HomePage
+        component: HomePage,
+        canActivate: [HomeGuard]
       }
     ])
   ],

--- a/projects/ranger/src/app/home/home.page.ts
+++ b/projects/ranger/src/app/home/home.page.ts
@@ -3,6 +3,8 @@ import {
   ViewChild
 } from '@angular/core';
 import {MapComponent} from '../map/map';
+import {MapPositionService} from '../map/position/map-position.service';
+import {Geoposition} from '@ionic-native/geolocation';
 
 @Component({
   selector: 'app-home',
@@ -14,6 +16,7 @@ export class HomePage {
   @ViewChild(MapComponent, {static: true}) map: MapComponent;
 
   constructor(
+    private mapPositionService: MapPositionService
   ) {
   }
 
@@ -28,7 +31,13 @@ export class HomePage {
    */
   ionViewWillEnter() {
     console.log('Map/Home Page: Will Enter');
-    this.map.openMap();
+    /* Tell MapPositionService to begin watching device position. */
+    this.mapPositionService.findOurPosition();
+
+    /* Once a position is determined, we can use it to open the map. */
+    this.mapPositionService.getCurrentPositionSubject().subscribe(
+      (geoPosition: Geoposition) => this.map.openMapAtPosition(geoPosition)
+    );
   }
 
 }

--- a/projects/ranger/src/app/map/add-loc-button/add-loc-button.ts
+++ b/projects/ranger/src/app/map/add-loc-button/add-loc-button.ts
@@ -6,6 +6,7 @@ import {
   LocationService
 } from 'cr-lib';
 import {MapDataService} from '../data/map-data.service';
+import {MapPositionService} from '../position/map-position.service';
 
 /**
  * Provides a button that upon clicking will query the map's current
@@ -22,13 +23,14 @@ export class AddLocButtonComponent {
     private latLonService: LatLonService,
     private locationService: LocationService,
     private mapDataService: MapDataService,
+    private mapPositionService: MapPositionService,
     private router: Router,
   ) {
     console.log('Hello AddLocButtonComponent Component');
   }
 
   addLocationAction(event: Event) {
-    const newGeoposition: Geoposition = this.mapDataService.getReportedPosition();
+    const newGeoposition: Geoposition = this.mapPositionService.getReportedPosition();
     alert(JSON.stringify(newGeoposition.coords));
 
     // TODO: CA-256 Turn this into AttractionService

--- a/projects/ranger/src/app/map/drag/map-drag.service.ts
+++ b/projects/ranger/src/app/map/drag/map-drag.service.ts
@@ -5,7 +5,7 @@ import {
   LatLonService
 } from 'cr-lib';
 import {Subject} from 'rxjs';
-import {MapDataService} from '../data/map-data.service';
+import {MapPositionService} from '../position/map-position.service';
 
 /**
  * This responds to map drag events and is a source of new position info which is pushed
@@ -24,9 +24,9 @@ export class MapDragService {
 
   constructor(
     private latLonService: LatLonService,
-    private mapDataService: MapDataService
+    private mapPositionService: MapPositionService
   ) {
-    this.centerSubject = mapDataService.getReportedPositionSubject();
+    this.centerSubject = mapPositionService.getReportedPositionSubject();
   }
 
   public isAutoCenter(): boolean {

--- a/projects/ranger/src/app/map/position/map-position.service.spec.ts
+++ b/projects/ranger/src/app/map/position/map-position.service.spec.ts
@@ -1,0 +1,12 @@
+import {TestBed} from '@angular/core/testing';
+
+import {MapPositionService} from './map-position.service';
+
+describe('MapPositionService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: MapPositionService = TestBed.get(MapPositionService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/ranger/src/app/map/position/map-position.service.ts
+++ b/projects/ranger/src/app/map/position/map-position.service.ts
@@ -1,0 +1,103 @@
+import {Injectable} from '@angular/core';
+import {Geoposition} from '@ionic-native/geolocation';
+import {
+  BehaviorSubject,
+  Observable,
+  ReplaySubject,
+  Subject
+} from 'rxjs';
+import {GeoLocService} from 'cr-lib';
+
+/**
+ * Responsible for:
+ * <ul>
+ *   <li>Obtaining suitable position sources (GPS/Device or Tether and via MapDrag).
+ *   <li>Able to send trigger once that position is known/settled (can involve asking permission to use GPS, for example).
+ *   <li>Maintains the map center, sometimes specifying the map's center and sometimes using the map's center.
+ *   <li>Serves to provide value for back-end know where we are so it can recommend appropriate geometry elements (mainly attractions).
+ * </ul>
+ *
+ * Collaborates with:
+ *
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class MapPositionService {
+  /* Where we are */
+  private currentPosition: Geoposition;
+  private currentPositionSubject: Subject<Geoposition> = new ReplaySubject<Geoposition>(1);
+
+  /* Our current Center of the map; can be different from GPS or Tether reported position when we drag the map. */
+  readonly reportedPosition: BehaviorSubject<Geoposition>;
+
+  private positionSourceKnownFlag: boolean;
+
+  constructor(
+    private geoLocService: GeoLocService
+  ) {
+    /* Set an Atlanta position if we don't have any other value yet. */
+    this.reportedPosition = new BehaviorSubject(GeoLocService.ATLANTA_GEOPOSITION);
+    this.positionSourceKnownFlag = false;
+  }
+
+  /**
+   * Kicks off finding source of where the device is located, not necessarily the center of the map.
+   */
+  public findOurPosition(): void {
+    /* Only subscribe once. */
+    if (this.positionSourceKnownFlag) {
+      console.log('Position subscription has been established; no need to try again');
+      return;
+    }
+
+    console.log("MapPositionService: findOurPosition()");
+    this.geoLocService.getPositionWatch().subscribe(
+      (geoPosition: Geoposition) => {
+        this.positionSourceKnownFlag = true;
+        this.currentPositionSubject.next(geoPosition)
+      }
+    );
+  }
+
+  /** Subject published when center of map is moved. */
+  public getReportedPositionSubject(): BehaviorSubject<Geoposition> {
+    return this.reportedPosition;
+  }
+
+  /** Geoposition published when center of map is moved. */
+  public getReportedPosition(): Geoposition {
+    return this.reportedPosition.getValue();
+  }
+
+  public getCurrentPosition(): Geoposition {
+    return this.currentPosition;
+  }
+
+  public getCurrentPositionSubject(): Subject<Geoposition> {
+    return this.currentPositionSubject;
+  }
+
+  /**
+   * Pays attention to the GeoLoc service to provide new positions and passes them along to
+   * the function which handles that new position.
+   *
+   * @param setNewCenterForMap function which is expected to respond to a new position.
+   */
+  public setWatch(
+    setNewCenterForMap: (position: Geoposition) => void
+  ): Observable<Geoposition> {
+    const positionObservable = this.geoLocService.getPositionWatch();
+    positionObservable.subscribe(
+      (position) => {
+        setNewCenterForMap(position);
+      }
+    );
+    return positionObservable;
+  }
+
+  public releaseWatch(): void {
+    this.geoLocService.clearWatch();
+  }
+
+}

--- a/projects/ranger/src/environments/environment.prod.ts
+++ b/projects/ranger/src/environments/environment.prod.ts
@@ -1,7 +1,7 @@
 export const environment = {
   production: true,
   build: {
-    gitSha: 'ce0844e',
-    date: '2020-02-21T01:30:58.570Z',
+    gitSha: '2b644a1',
+    date: '2020-03-22T23:56:33.666Z',
   }
 };

--- a/projects/ranger/updateBuildInfo.js
+++ b/projects/ranger/updateBuildInfo.js
@@ -1,3 +1,4 @@
+/* This script is used to add the git SHA and Build Date to the environment for inclusion on the About page. */
 const replace = require('replace-in-file');
 const git = require('git-rev-sync');
 const gitSha = git.short();


### PR DESCRIPTION
- Factors out the MapPositionService from the MapDataService.
- Tightens the state machine for sequencing the loading of Location Types, Categories, Attractions, and the AttractionLayers.
- Adds Home Page guard to avoid the default navigation to the Home Page prior to
all attempts to delay the explicit navigation to the Home Page.
- Clarifies the collaboration between FilterService, MapDataService, and AttractionLayerService for determining how to get the layers onto the Map.
- Ensures we have a valid position source prior to retrieving Attraction information from the back-end; avoids multiple back-end calls.
- Stabilizes the invocation for presenting the map (biggest part was the Home Page guard).

This does function mostly. Items found while working on this are being captured in CA-447.