### PR TITLE
CI-175 MapDataService: can we use a LayerGroup instead of a Map?

### DIFF
--- a/projects/cr-lib/src/lib/api/category/category.service.ts
+++ b/projects/cr-lib/src/lib/api/category/category.service.ts
@@ -5,6 +5,8 @@ import {
   BASE_URL
 } from '../../auth/header/auth-header.service';
 import {Category} from './category';
+import {Observable} from 'rxjs';
+import {tap} from 'rxjs/operators';
 
 /**
  * Service support for Category instances.
@@ -22,21 +24,26 @@ export class CategoryService {
     private authHeaderService: AuthHeaderService
   ) {
     console.log('Hello CategoryService');
-    this.loadSync();
   }
 
-  public async loadSync() {
-    await this.http.get<Category[]>(
+  /**
+   * Populates the cached copy of the Categories as well as returning the same as an Observable
+   * so we know when it completes.
+   */
+  // public load(): Observable<Category[]> {
+  public load(): Observable<Category[]> {
+    console.log('CategoryService.load()');
+    return this.http.get<Category[]>(
       BASE_URL + 'category',
       {headers: this.authHeaderService.getAuthHeaders()}
-    ).subscribe(
-      (response) => {
+    ).pipe(
+      tap (response => {
         response.forEach(category => {
           this.categories.push(category);
           this.categoriesById[category.id] = category;
         });
         console.log('Category Cache filled. total: ' + this.categories.length);
-      }
+      })
     );
   }
 

--- a/projects/cr-lib/src/lib/api/loc-type/loc-type.service.ts
+++ b/projects/cr-lib/src/lib/api/loc-type/loc-type.service.ts
@@ -1,16 +1,13 @@
 import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
-import {
-  from,
-  Observable,
-  Subject
-} from 'rxjs';
+import {Observable} from 'rxjs';
 import {
   AuthHeaderService,
   BASE_URL
 } from '../../auth/header/auth-header.service';
-import {CategoryService} from '../category/category.service';
 import {LocationType} from './loc-type';
+import {Category} from '../category/category';
+import {tap} from 'rxjs/operators';
 
 interface LocTypeCategoryMap {
   [index: number]: LocationType[];
@@ -27,50 +24,37 @@ export class LocTypeService {
   constructor(
     public http: HttpClient,
     private httpService: AuthHeaderService,
-    private categoryService: CategoryService,
   ) {
-    /* Reserve an empty array for each of the known Categories. */
-    // TODO: Not sure why this doesn't execute prior to the initializeCache call.
-    // this.categoryService.getAllCategories().subscribe(
-    from([1, 4, 5, 6, 7, 8, 10]).subscribe(
-      (category) => {
-        // this.locTypeByCategory[category.id] = [];
-        this.locTypeByCategory[category] = [];
-      }
-    );
   }
 
   /**
-   * Builds cached map of LocationTypeID -> LocationType from resource, but
-   * only if we haven't already populated the cache.
+   * Loads cached map of LocationTypeID -> LocationType from resource and
+   * returns as an Observable so we know when this completes.
    */
-  public initializeCache(): Observable<boolean> {
-    const cacheFilledSubject: Subject<boolean> = new Subject<boolean>();
+  public load(categories: Category[]): Observable<LocationType[]> {
+    /* Reserve an empty array for each of the known Categories. */
+    categories.forEach(
+      (category) => this.locTypeByCategory[category.id] = []
+    );
 
-    if (LocTypeService.locationTypeCache.length === 0) {
-      this.http.get<LocationType[]>(
-        BASE_URL + 'location/types',
-        {headers: this.httpService.getAuthHeaders()}
-      ).subscribe(
-        (response) =>  {
-          response.forEach(locType => {
-            LocTypeService.locationTypeCache[locType.id] = locType;
-            console.log('LocTypeService: classifying', locType.name);
-            if (locType.category) {
-              this.locTypeByCategory[locType.category.id].push(locType);
-            } else {
-              console.log('Location Type ' + locType.name + ' has no category assigned');
-            }
-          });
-          console.log('Loc Type Cache filled. total: ' + LocTypeService.locationTypeCache.length);
-          cacheFilledSubject.next(true);
-        }
-      );
-    } else {
-      cacheFilledSubject.next(true);
-    }
+    return this.http.get<LocationType[]>(
+      BASE_URL + 'location/types',
+      {headers: this.httpService.getAuthHeaders()}
+    ).pipe(
+      tap((response) =>  {
+        response.forEach(locType => {
+          LocTypeService.locationTypeCache[locType.id] = locType;
+          console.log('LocTypeService: classifying', locType.name);
+          if (locType.category) {
+            this.locTypeByCategory[locType.category.id].push(locType);
+          } else {
+            console.log('Location Type ' + locType.name + ' has no category assigned');
+          }
+        });
+        console.log('Loc Type Cache filled. total: ' + LocTypeService.locationTypeCache.length);
+      })
+    );
 
-    return cacheFilledSubject.asObservable();
   }
 
   public allLocationTypes(): Array<LocationType> {

--- a/projects/ranger/src/environments/environment.prod.ts
+++ b/projects/ranger/src/environments/environment.prod.ts
@@ -1,7 +1,7 @@
 export const environment = {
   production: true,
   build: {
-    gitSha: '2b644a1',
-    date: '2020-03-22T23:56:33.666Z',
+    gitSha: '27f18ff',
+    date: '2020-03-24T10:34:00.773Z',
   }
 };


### PR DESCRIPTION
- Changes L.Map into L.LayerGroup in MapDataService as well as AttractionLayerService.
- Refactors sequencing to use a FlatMap approach. This appears to work well, but
need to wrap tests around it.

This started into testing, but ended up refactoring a bunch of this to make it easier to test.