### PR TITLE
CI-182 Filter doesn't handle the Course option

### DIFF
--- a/projects/cr-lib/src/lib/api/attraction/attraction-service.spec.ts
+++ b/projects/cr-lib/src/lib/api/attraction/attraction-service.spec.ts
@@ -1,4 +1,3 @@
-import {HttpClient} from '@angular/common/http';
 import {AuthHeaderService} from '../../auth/header/auth-header.service';
 import {OutingService} from '../outing/outing.service';
 import {AttractionService} from './attraction.service';
@@ -7,6 +6,7 @@ const authHeaderSpy = jasmine.createSpyObj('AuthHeaderService', ['get']);
 const httpClientSpy = jasmine.createSpyObj('HttpClient', ['get']);
 const outingSpy = jasmine.createSpyObj('OutingService', ['get']);
 const locationSpy = jasmine.createSpyObj('LocationService', ['get']);
+const locTypeSpy = jasmine.createSpyObj('LocTypeService', ['get']);
 
 describe('attraction-service', () => {
   let toTest: AttractionService;
@@ -16,7 +16,8 @@ describe('attraction-service', () => {
       httpClientSpy,
       authHeaderSpy,
       outingSpy,
-      locationSpy
+      locationSpy,
+      locTypeSpy
     );
   });
 

--- a/projects/cr-lib/src/lib/api/attraction/course/course-attraction.service.spec.ts
+++ b/projects/cr-lib/src/lib/api/attraction/course/course-attraction.service.spec.ts
@@ -8,6 +8,8 @@ import {BASE_URL} from '../../../auth/header/auth-header.service';
 import {AttractionMock} from '../attraction-mock';
 
 import {CourseAttractionService} from './course-attraction.service';
+import {LatLonService} from '../../../domain/lat-lon/lat-lon.service';
+import {PoolMarkerService} from '../../../marker/pool/pool-marker.service';
 
 /* Populate a set of Attractions to serve as the Course. */
 const attraction1 = AttractionMock.createAttractionMock(1);
@@ -23,22 +25,27 @@ const attractionsForCourse = [
   attraction5,
 ];
 
+const latLonSpy = jasmine.createSpyObj('LatLonService', ['getAllCategories']);
+const poolMarkerSpy = jasmine.createSpyObj('PoolMarkerService', ['getAllCategories']);
+
 describe('CourseAttractionService', () => {
   let toTest: CourseAttractionService;
-  let httpMock: HttpTestingController;
+  let httpClientSpy: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [
-        CourseAttractionService
-      ],
       imports: [
         HttpClientTestingModule
+      ],
+      providers: [
+        CourseAttractionService,
+        { provide: LatLonService, useValue: latLonSpy },
+        { provide: PoolMarkerService, useValue: poolMarkerSpy },
       ]
     });
 
     toTest = TestBed.get(CourseAttractionService);
-    httpMock = TestBed.get(HttpTestingController);
+    httpClientSpy = TestBed.get(HttpTestingController);
   });
 
   it('should be created', () => {
@@ -60,11 +67,11 @@ describe('CourseAttractionService', () => {
         }
       );
 
-      const attractionRequest: TestRequest = httpMock.expectOne(BASE_URL + 'location/active');
+      const attractionRequest: TestRequest = httpClientSpy.expectOne(BASE_URL + 'location/active');
       attractionRequest.flush(attractionsForCourse);
 
       /* verify results */
-      httpMock.verify();
+      httpClientSpy.verify();
       const actual = toTest.getAllCourseAttractions();
       expect(actual).toEqual(attractionsForCourse);
       expect(toTest.getAttraction(1)).toEqual(attraction1);
@@ -91,7 +98,7 @@ describe('CourseAttractionService', () => {
         }
       );
 
-      const attractionRequest: TestRequest = httpMock.expectOne(BASE_URL + 'location/active');
+      const attractionRequest: TestRequest = httpClientSpy.expectOne(BASE_URL + 'location/active');
       attractionRequest.flush(attractionsForCourse);
 
       /* make call */
@@ -111,7 +118,7 @@ describe('CourseAttractionService', () => {
         }
       );
 
-      const attractionRequest: TestRequest = httpMock.expectOne(BASE_URL + 'location/active');
+      const attractionRequest: TestRequest = httpClientSpy.expectOne(BASE_URL + 'location/active');
       attractionRequest.flush(attractionsForCourse);
 
       /* make call */
@@ -141,11 +148,11 @@ describe('CourseAttractionService', () => {
         }
       );
 
-      const attractionRequest: TestRequest = httpMock.expectOne(BASE_URL + 'location/active');
+      const attractionRequest: TestRequest = httpClientSpy.expectOne(BASE_URL + 'location/active');
       attractionRequest.flush(attractionsForCourse);
 
       /* verify results */
-      httpMock.verify();
+      httpClientSpy.verify();
       const actual = toTest.getAllCourseAttractions();
       expect(actual).toEqual(attractionsForCourse);
       expect(toTest.getAttraction(1)).toEqual(attraction1);

--- a/projects/cr-lib/src/lib/filter/filter.service.ts
+++ b/projects/cr-lib/src/lib/filter/filter.service.ts
@@ -27,14 +27,13 @@ export class FilterService {
 
     this.currentFilter = {
       categoriesToIncludeById: [],
-      outingToInclude: null,
+      courseToInclude: null,
       isEmpty: true
     };
   }
 
   public changeFilter(filter: Filter) {
     this.currentFilter = filter;
-    filter.isEmpty = (filter.categoriesToIncludeById.length === 0);
     this.filterSubject.next(filter);
   }
 

--- a/projects/cr-lib/src/lib/filter/filter.ts
+++ b/projects/cr-lib/src/lib/filter/filter.ts
@@ -11,6 +11,6 @@
 /** Default is to include nothing. */
 export class Filter {
   categoriesToIncludeById: number[] = [];
-  outingToInclude: number = null;
+  courseToInclude: number = null;
   isEmpty: boolean = true;
 }

--- a/projects/cr-lib/src/lib/filter/popover/popover.component.html
+++ b/projects/cr-lib/src/lib/filter/popover/popover.component.html
@@ -2,12 +2,14 @@
   <ion-label>Course</ion-label>
 
   <ion-select class="ion-select-for-filter"
+              [(ngModel)]="filter.courseToInclude"
+              (ionChange)="courseHasChanged($event)"
               placeholder="No Courses included"
-              interface="alert"
-              multiple="true"
-              okText="Okay"
-              cancelText="Nah">
-    <ion-select-option *ngFor="let course of courses">
+              multiple="false"
+              okText="OK"
+              cancelText="Cancel">
+    <ion-select-option *ngFor="let course of courses"
+                       [value]="course.id">
       {{course.name}}
     </ion-select-option>
   </ion-select>

--- a/projects/cr-lib/src/lib/filter/popover/popover.component.ts
+++ b/projects/cr-lib/src/lib/filter/popover/popover.component.ts
@@ -9,6 +9,10 @@ import {CategoryService} from '../../api/category/category.service';
 import {Course} from '../../api/course/course';
 import {CourseService} from '../../api/course/course.service';
 
+/**
+ * Responsible for populating the values that show up in the pull-downs
+ * on the Filter Popover.
+ */
 @Component({
   selector: 'app-filter-popover',
   templateUrl: './popover.component.html',
@@ -20,9 +24,20 @@ export class FilterPopoverComponent implements OnInit {
   public courses: Course[];
   public categories: Category[];
 
-  /* Passing CSS to the popover. */
+  readonly noCourseSelected: Course = {
+    id: 0,
+    name: 'No Course',
+    courseTypeId: null,
+    description: 'No Course Selected',
+    departure: '',
+    destination: '',
+    pathIds: [],
+    url: ''
+  };
+
+  /* Passing CSS to the popover; exposed to the HTML template. */
   public categoryAlertOptions: any = {
-    cssClass: "category-alert"
+    cssClass: 'category-alert'
   };
 
   constructor(
@@ -38,12 +53,33 @@ export class FilterPopoverComponent implements OnInit {
     this.courseService.getAllCourses().subscribe(
       (courses) => {
         this.courses = courses;
+        this.courses.push(this.noCourseSelected);
       }
     );
   }
 
+  /**
+   * Invoked when Course selection is made.
+   *
+   * @param event details of the Course changes.
+   */
+  courseHasChanged(event: CustomEvent) {
+    const courseId = event.detail.value;
+    if (courseId === 0 || courseId === '') {
+      this.filter.courseToInclude = null;
+    } else {
+      this.filter.courseToInclude = courseId;
+    }
+    this.filter.isEmpty = this.checkIfFilterEmpty();
+    this.filterService.changeFilter(this.filter);
+  }
+
+  /**
+   * Invoked when Category selection is made.
+   *
+   * @param event details of the changes.
+   */
   categoryHasChanged(event: CustomEvent) {
-    console.log(event);
     this.filter.categoriesToIncludeById = event.detail.value;
     this.filter.isEmpty = this.checkIfFilterEmpty();
     this.filterService.changeFilter(this.filter);
@@ -52,7 +88,7 @@ export class FilterPopoverComponent implements OnInit {
   checkIfFilterEmpty(): boolean {
     return (
       this.filter.categoriesToIncludeById.length === 0 &&
-      this.filter.outingToInclude != null
+      this.filter.courseToInclude === null
     );
   }
 

--- a/projects/ranger/src/app/filter/page/filter.page.ts
+++ b/projects/ranger/src/app/filter/page/filter.page.ts
@@ -59,7 +59,7 @@ export class FilterPageComponent implements OnInit {
   checkIfFilterEmpty(): boolean {
     return (
       this.filter.categoriesToIncludeById.length === 0 &&
-      this.filter.outingToInclude != null
+      this.filter.courseToInclude != null
     );
   }
 

--- a/projects/ranger/src/environments/environment.prod.ts
+++ b/projects/ranger/src/environments/environment.prod.ts
@@ -1,7 +1,7 @@
 export const environment = {
   production: true,
   build: {
-    gitSha: 'a2172be',
-    date: '2020-04-19T13:57:28.364Z',
+    gitSha: '3e1d412',
+    date: '2020-04-19T20:33:36.300Z',
   }
 };


### PR DESCRIPTION
- Creates separate LayerGroup for the Course Markers.
- Adds function to retrieve and show the attractions for a selected Course.
- Builds up the idea for an AttractionService call that performs the LocationType assembly RxJS style.
- Updates Popover to accommodate Course.
- Adds Subject for Bounds Changes so the selected course markers can be centered upon filtering on those markers.
- Removes unnecessary add/update functions from the MapComponent (the layers are more independent now).