### PR TITLE
CI-240 New Course isn't working

### DIFF
--- a/projects/course/src/app/course-list/course-list.page.ts
+++ b/projects/course/src/app/course-list/course-list.page.ts
@@ -1,11 +1,11 @@
 import {
-  Component,
-  OnInit
+    Component,
+    OnInit
 } from '@angular/core';
 import {
-  Course,
-  CourseService,
-  LoaderService
+    Course,
+    CourseService,
+    LoaderService
 } from 'cr-lib';
 import {Router} from '@angular/router';
 import {EditedCourseService} from '../course/edited-course.service';
@@ -34,11 +34,15 @@ export class CourseListPage implements OnInit {
     console.log("Adding new Course");
     let newCourse = new Course();
 
-    this.editedCourseService.setEditedCourse(newCourse);
-    this.router.navigate(
-      ['course/' + newCourse.id + '/details']
-    ).then(() => console.log('Successful launch of Course Page')
-    ).catch( (error) => console.log('Failed to launch Course Page. How come?', error)
+    this.editedCourseService.createCourse(newCourse).subscribe(
+        (newCourse: Course) => {
+          this.editedCourseService.setEditedCourse(newCourse);
+          this.router.navigate(
+              ['course/' + newCourse.id + '/details']
+          ).then(() => console.log('Successful launch of Course Page')
+          ).catch( (error) => console.log('Failed to launch Course Page. How come?', error)
+          );
+        }
     );
   }
 

--- a/projects/course/src/app/course/attractions/attractions-sequence-page.component.ts
+++ b/projects/course/src/app/course/attractions/attractions-sequence-page.component.ts
@@ -56,7 +56,7 @@ export class AttractionsSequencePage implements OnInit {
 
   save() {
     this.loaderService.showLoader('Saving Course');
-    this.editedCourseService.saveNewCourse(this.course).subscribe(
+    this.editedCourseService.updateCourse(this.course).subscribe(
       (updatedCourse: Course) => {
         this.loaderService.hideLoader();
       },

--- a/projects/course/src/app/course/details/details.page.html
+++ b/projects/course/src/app/course/details/details.page.html
@@ -3,14 +3,15 @@
     <ion-buttons slot="start">
       <ion-back-button></ion-back-button>
     </ion-buttons>
-    <ion-title *ngIf="course.name">{{course.name}} - Details</ion-title>
-    <ion-title *ngIf="!course.name">Edit Course</ion-title>
+    <ion-title *ngIf="course && course.name">{{course.name}} - Details</ion-title>
+    <ion-title *ngIf="!course || !course.name">Edit Course</ion-title>
   </ion-toolbar>
 </ion-header>
 
 <ion-content>
 
-  <div [formGroup]="detailsGroup">
+  <div [formGroup]="detailsGroup"
+        *ngIf="course">
 
     <ion-list>
       <!-- Name -->

--- a/projects/course/src/app/course/details/details.page.ts
+++ b/projects/course/src/app/course/details/details.page.ts
@@ -63,6 +63,7 @@ export class DetailsPage implements OnInit, OnDestroy {
       (params) => {
         this.courseId = parseInt(this.activatedRoute.snapshot.paramMap.get('id'), 10);
         this.course = this.editedCourseService.getCourseToEdit(this.courseId);
+        console.log('Found course ID', this.course.id);
       },
       (error) => console.log('DetailsPage: Unable to pick up query params', error)
     );
@@ -81,7 +82,7 @@ export class DetailsPage implements OnInit, OnDestroy {
 
   save() {
     this.loaderService.showLoader('Saving Course');
-    this.editedCourseService.saveNewCourse(this.course).subscribe(
+    this.editedCourseService.updateCourse(this.course).subscribe(
       (updatedCourse: Course) => {
         this.loaderService.hideLoader();
       },

--- a/projects/course/src/app/course/edited-course.service.ts
+++ b/projects/course/src/app/course/edited-course.service.ts
@@ -36,11 +36,22 @@ export class EditedCourseService {
     return this.editedCourseSubject.asObservable();
   }
 
-  public saveNewCourse(newCourse: Course): Observable<Course> {
-    return this.courseService.saveNewCourse(newCourse)
+  public createCourse(newCourse: Course): Observable<Course> {
+    return this.courseService.createCourse(newCourse)
+      .pipe(
+        tap((updatedCourse: Course) => {
+          this.editedCourseSubject.next(updatedCourse);
+          this.courseMap[updatedCourse.id] = updatedCourse;
+        })
+      );
+  }
+
+  public updateCourse(course: Course): Observable<Course> {
+    return this.courseService.updateCourse(course)
       .pipe(
         tap((updatedCourse: Course) => this.editedCourseSubject.next(updatedCourse))
       );
+
   }
 
   public getCourseToEdit(courseId: number) {

--- a/projects/cr-lib/src/lib/api/course/course.service.ts
+++ b/projects/cr-lib/src/lib/api/course/course.service.ts
@@ -101,12 +101,27 @@ export class CourseService {
   }
 
   /**
-   * Posts a new course to the back-end.
+   * Updates an existing course to the back-end.
    *
-   * @param newCourse
+   * @param course with an ID assigned by the API.
    */
-  public saveNewCourse(newCourse: Course): Observable<Course> {
+  public updateCourse(course: Course): Observable<Course> {
     return this.http.post<Course>(
+      BASE_URL + 'course',
+      course,
+      {
+        headers: this.httpService.getAuthHeaders()
+      }
+    )
+  }
+
+  /**
+   * Puts a new course to the back-end.
+   *
+   * @param newCourse - instance without an ID yet.
+   */
+  public createCourse(newCourse: Course): Observable<Course> {
+    return this.http.put<Course>(
       BASE_URL + 'course',
       newCourse,
       {
@@ -114,5 +129,6 @@ export class CourseService {
       }
     )
   }
+
 
 }


### PR DESCRIPTION
- Separate call for new course vs existing course for EditedCourse Service.
- Create a new course with a specific ID at the time we ask for a new course.
- Ask the EditedCourse Service to update its internal list so navigation can pick up
the newly created course record.

Not sure how it works, but the newly created Course doesn't get persisted unless there is actual
data as part of the course. Seems to be working well.