### PR TITLE
CI-244 Readiness of an Attraction should be shown on a Course listing…

### DIFF
--- a/projects/course/src/app/course/attractions/attractions-sequence-page.component.html
+++ b/projects/course/src/app/course/attractions/attractions-sequence-page.component.html
@@ -20,8 +20,7 @@
               [attr.data-index]="i">
 
       <span slot="start">
-        <ion-icon [name]="attraction.locationTypeIconName">
-        </ion-icon>
+        <app-attraction-icon [attraction]="attraction"></app-attraction-icon>
       </span>
 
       <span>

--- a/projects/course/src/app/course/attractions/attractions.module.ts
+++ b/projects/course/src/app/course/attractions/attractions.module.ts
@@ -11,6 +11,7 @@ import {IonicModule} from '@ionic/angular';
 import {AttractionsSequencePage} from './attractions-sequence-page.component';
 import {AttractionSuggestComponent} from '../attraction-suggest/attraction-suggest.component';
 import {EdgeModule} from '../../edge/edge.module';
+import {AttractionIconModule} from 'cr-lib';
 
 const routes: Routes = [
   {
@@ -21,6 +22,7 @@ const routes: Routes = [
 
 @NgModule({
   imports: [
+    AttractionIconModule,
     CommonModule,
     EdgeModule,
     FormsModule,

--- a/projects/course/src/index.html
+++ b/projects/course/src/index.html
@@ -13,6 +13,12 @@
 
   <link rel="icon" type="image/png" href="assets/icon/favicon.png" />
 
+  /* Images for the Font Awesome icons won't be found if we don't include this. */
+  <link rel="stylesheet"
+        href="https://use.fontawesome.com/releases/v5.8.1/css/all.css"
+        integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf"
+        crossorigin="anonymous" />
+
   <!-- add to homescreen for ios -->
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black" />

--- a/projects/cr-lib/src/lib/api/attraction/icon/attraction-icon.component.html
+++ b/projects/cr-lib/src/lib/api/attraction/icon/attraction-icon.component.html
@@ -1,0 +1,8 @@
+<ion-icon class="type-icon fas fa-{{attraction.locationTypeIconName}}"
+          [ngClass]="{
+                    draft: attraction.readinessLevel.startsWith('DRAFT'),
+                    place: attraction.readinessLevel.startsWith('PLACE'),
+                    attraction: attraction.readinessLevel.startsWith('ATTRACTION'),
+                    feature: attraction.readinessLevel.startsWith('FEATURE')
+                  }">
+</ion-icon>

--- a/projects/cr-lib/src/lib/api/attraction/icon/attraction-icon.component.scss
+++ b/projects/cr-lib/src/lib/api/attraction/icon/attraction-icon.component.scss
@@ -1,0 +1,23 @@
+@import '../../../shared-style';
+
+.type-icon {
+  font-size: x-large;
+  color: white;
+  padding: 10px;
+}
+
+.draft {
+  background-color: $draft;
+}
+
+.place {
+  background-color: $place;
+}
+
+.attraction {
+  background-color: $attraction;
+}
+
+.feature {
+  background-color: $feature;
+}

--- a/projects/cr-lib/src/lib/api/attraction/icon/attraction-icon.component.spec.ts
+++ b/projects/cr-lib/src/lib/api/attraction/icon/attraction-icon.component.spec.ts
@@ -1,0 +1,31 @@
+import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
+import {
+  async,
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+
+import {AttractionIconComponent} from './attraction-icon.component';
+
+describe('AttractionIconComponent', () => {
+  let component: AttractionIconComponent;
+  let fixture: ComponentFixture<AttractionIconComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AttractionIconComponent ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AttractionIconComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/cr-lib/src/lib/api/attraction/icon/attraction-icon.component.ts
+++ b/projects/cr-lib/src/lib/api/attraction/icon/attraction-icon.component.ts
@@ -1,0 +1,21 @@
+import {
+  Component,
+  Input,
+  OnInit
+} from '@angular/core';
+import {Attraction} from '../attraction';
+
+@Component({
+  selector: 'app-attraction-icon',
+  templateUrl: './attraction-icon.component.html',
+  styleUrls: ['./attraction-icon.component.scss'],
+})
+export class AttractionIconComponent implements OnInit {
+
+  @Input() attraction: Attraction;
+
+  constructor() { }
+
+  ngOnInit() {}
+
+}

--- a/projects/cr-lib/src/lib/api/attraction/icon/attraction-icon.module.ts
+++ b/projects/cr-lib/src/lib/api/attraction/icon/attraction-icon.module.ts
@@ -1,0 +1,14 @@
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {AttractionIconComponent} from './attraction-icon.component';
+import {IonicModule} from '@ionic/angular';
+
+@NgModule({
+  declarations: [AttractionIconComponent],
+  imports: [
+    CommonModule,
+    IonicModule,
+  ],
+  exports: [AttractionIconComponent]
+})
+export class AttractionIconModule { }

--- a/projects/cr-lib/src/lib/shared-style.scss
+++ b/projects/cr-lib/src/lib/shared-style.scss
@@ -5,5 +5,12 @@ $adept: #068E07;
 $advocate: #0410FF;
 $angel: #8A07FF;
 
+// The Same colors show the Readiness Level of an Attraction:
+
+$draft: $aware;
+$place: $adept;
+$attraction: $advocate;
+$feature: $angel;
+
 // ... and the Banner's color
 $banner: #07007E;

--- a/projects/cr-lib/src/public-api.ts
+++ b/projects/cr-lib/src/public-api.ts
@@ -11,6 +11,7 @@ export * from './lib/api/attraction/attraction.service';
 export * from './lib/api/attraction/bounds/bounds-service';
 export * from './lib/api/attraction/course/course-attraction.service';
 export * from './lib/api/attraction/category/category-attraction.service';
+export * from './lib/api/attraction/icon/attraction-icon.module';
 export * from './lib/api/attraction/layer/attraction-layer.service';
 export * from './lib/api/attraction/path/attraction-by-path.service';
 export * from './lib/api/attraction/path/path-meta';


### PR DESCRIPTION
… in the editor

- Adds new component to show the Font Awesome icon that matches the Icon Name provided for attractions with a Location Type.
- Adds the import of the Font Awesome CSS to the index page of the Course App.
- Updates the shared-style.scss to use Readiness Level names for the colors.

This takes advantage of the Server populating the Icon Name instead of just providing the Loc Type ID (SVR-128).