### PR TITLE
CI-254 Instead of showing the Start Location, we should show the Outi…

### DIFF
--- a/projects/player/src/app/outing-page/outing-page.guard.spec.ts
+++ b/projects/player/src/app/outing-page/outing-page.guard.spec.ts
@@ -1,0 +1,18 @@
+import {
+  inject,
+  TestBed
+} from '@angular/core/testing';
+
+import {OutingPageGuard} from './outing-page.guard';
+
+describe('OutingPageGuard', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [OutingPageGuard]
+    });
+  });
+
+  it('should ...', inject([OutingPageGuard], (guard: OutingPageGuard) => {
+    expect(guard).toBeTruthy();
+  }));
+});

--- a/projects/player/src/app/outing-page/outing-page.guard.ts
+++ b/projects/player/src/app/outing-page/outing-page.guard.ts
@@ -1,0 +1,27 @@
+import {Injectable} from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  RouterStateSnapshot,
+  UrlTree
+} from '@angular/router';
+import {Observable} from 'rxjs';
+import {LoadStateService} from '../state/load/load-state.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class OutingPageGuard implements CanActivate {
+
+  constructor(
+    private loadStateService: LoadStateService,
+  ) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    return this.loadStateService.getLoadStateObservable();
+  }
+
+}

--- a/projects/player/src/app/outing-page/outing.module.ts
+++ b/projects/player/src/app/outing-page/outing.module.ts
@@ -6,6 +6,7 @@ import {ConnectionStateModule} from 'cr-lib';
 import {PinnedMapModule} from '../pinned-map/pinned-map.module';
 import {ShowGameModule} from '../show-game/show-game.module';
 import {OutingPage} from './outing.page';
+import {OutingPageGuard} from './outing-page.guard';
 
 @NgModule({
   declarations: [
@@ -20,7 +21,8 @@ import {OutingPage} from './outing.page';
     RouterModule.forChild([
       {
         path: 'outing',
-        component: OutingPage
+        component: OutingPage,
+        canActivate: [OutingPageGuard]
       }
     ]),
   ],

--- a/projects/player/src/app/outing-page/outing.page.html
+++ b/projects/player/src/app/outing-page/outing.page.html
@@ -50,8 +50,7 @@
 
   Starting Location
   <app-pinned-map class="map-content"
-                  [startingLocationObservable]="startingAttractionSubject"
-                  [pin]='outing.startPin'>
+                  [startingLocationObservable]="startingAttractionSubject">
   </app-pinned-map>
 
   <app-show-game></app-show-game>

--- a/projects/player/src/app/outing-page/outing.page.ts
+++ b/projects/player/src/app/outing-page/outing.page.ts
@@ -37,23 +37,22 @@ export class OutingPage implements OnDestroy {
     private courseAttractionService: CourseAttractionService,
     private router: Router,
   ) {
+    console.log("Outing Page Constructor");
     this.startingAttractionSubject = new ReplaySubject<Attraction>(1);
   }
 
   ionViewDidEnter() {
     this.outingService.getSessionOuting().subscribe(
       /* Generally, the Outing has been cached. */
-      (response) => {
+      (outing) => {
         console.log('Receiving Outing from Service');
-        this.outing = response;
+        this.outing = outing;
 
         /* With the outing, we can load the starting location. */
-        this.startingAttractionSubject.next(
-          this.courseAttractionService.getAttraction(
-            this.outing.startingLocationId
-          )
+        let startingLocation: Attraction = this.courseAttractionService.getAttraction(
+          this.outing.startingLocationId
         );
-
+        this.startingAttractionSubject.next(startingLocation);
       }
     );
   }

--- a/projects/player/src/app/pinned-map/pinned-map.component.ts
+++ b/projects/player/src/app/pinned-map/pinned-map.component.ts
@@ -7,7 +7,6 @@ import {
 import {
   Attraction,
   GameMarkerService,
-  LatLon,
   LatLonService
 } from 'cr-lib';
 import * as L from 'leaflet';
@@ -30,7 +29,7 @@ export class PinnedMapComponent implements OnInit, OnDestroy {
   static map: any;
 
   @Input() startingLocationObservable: Observable<Attraction>;
-  @Input() pin: LatLon;
+
   zoomLevel = 14;
   subscription: Subscription;
   loading: boolean;

--- a/projects/player/src/app/show-game/show-game.service.ts
+++ b/projects/player/src/app/show-game/show-game.service.ts
@@ -38,9 +38,9 @@ export class ShowGameService {
   routeBasedOnGameState(gameState: GameState): void {
     let promise;
 
-    if (
-      gameState.rolling || !gameState.teamAssembled || gameState.outingComplete
-    ) {
+    if (!gameState.teamAssembled) {
+      promise = this.router.navigate(['outing']);
+    } else if (gameState.rolling || gameState.outingComplete) {
       promise = this.router.navigate(['rolling']);
     } else {
       promise = this.router.navigate(['puzzle', gameState.puzzleId]);


### PR DESCRIPTION
…ng View when first coming up

- Specifically routes to the Outing page when the game hasn't yet started.
- When returning to the outing page from viewing the Clue Ride website, the attraction doesn't get loaded and
an exception was being thrown. This led to a couple of things:
  - Removed the unused 'Pin' LatLon value for the pinned-map.component.ts.
  - Added a Guard to the Outing page to wait until the data load had completed.

Waiting for DataLoad might be a good thing to add to a bunch of guards.
Instead of writing the Guard such that it is page-specific, we can make it condition specific -- the inclusion of
the guard states what kind of wait is being performed.