### PR TITLE
CI-269 Add Explicit check with back-end against a given token when fi…

### DIFF
--- a/projects/cr-lib/src/lib/api/access-token/access-token.service.spec.ts
+++ b/projects/cr-lib/src/lib/api/access-token/access-token.service.spec.ts
@@ -1,0 +1,12 @@
+import {TestBed} from '@angular/core/testing';
+
+import {AccessTokenService} from './access-token.service';
+
+describe('AccessTokenService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: AccessTokenService = TestBed.get(AccessTokenService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/cr-lib/src/lib/api/access-token/access-token.service.ts
+++ b/projects/cr-lib/src/lib/api/access-token/access-token.service.ts
@@ -1,0 +1,46 @@
+import {Injectable} from '@angular/core';
+import {Observable} from 'rxjs';
+import {Member} from '../member/member';
+import {
+  AuthHeaderService,
+  BASE_URL
+} from '../../auth/header/auth-header.service';
+import {HttpClient} from '@angular/common/http';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AccessTokenService {
+
+  constructor(
+    private authHeaderService: AuthHeaderService,
+    private http: HttpClient,
+  ) { }
+
+  /**
+   * Checks against the back-end that our current token is valid.
+   */
+  public isTokenValid(): Observable<boolean> {
+    return this.http.get<boolean>(
+      BASE_URL + 'access/state',
+      {headers: this.authHeaderService.getAuthHeaders()}
+    );
+  }
+
+  /**
+   * Persists new profile once user has confirmed the email address they wish to use.
+   *
+   * This sends the profile obtained from parsing the JWT token so it can be compared
+   * to what the AuthHeaders would provide when presented to the 3rd-party Auth service.
+   */
+  public createNewProfile(member: Member): Observable<Member> {
+    console.log('Talking to the backend to create new User Profile');
+
+    return this.http.post<Member>(
+      BASE_URL + 'access/state/init',
+      member,
+      {headers: this.authHeaderService.getAuthHeaders()}
+    );
+  }
+
+}

--- a/projects/cr-lib/src/lib/api/profile/profile.service.ts
+++ b/projects/cr-lib/src/lib/api/profile/profile.service.ts
@@ -17,6 +17,7 @@ import {
 import {TokenService} from '../../auth/token/token.service';
 import {Member} from '../member/member';
 import {MemberService} from '../member/member.service';
+import {AccessTokenService} from '../access-token/access-token.service';
 
 /**
  * Responsible for the Member's Profile.
@@ -39,8 +40,9 @@ export class ProfileService {
   private memberSubject: Subject<Member>;
 
   constructor(
-    public http: HttpClient,
+    private accessTokenService: AccessTokenService,
     private authHeaderService: AuthHeaderService,
+    private http: HttpClient,
     private memberService: MemberService,
     private tokenService: TokenService,
   ) {
@@ -168,19 +170,9 @@ export class ProfileService {
     return this.cachedMember.id;
   }
 
-  /**
-   * Persists new profile once user has confirmed the email address they wish to use.
-   *
-   * This sends the profile obtained from parsing the JWT token so it can be compared
-   * to what the AuthHeaders would provide when presented to the 3rd-party Auth service.
-   */
   public createNewProfile(): Observable<Member> {
-    console.log('Talking to the backend to create new User Profile');
-
-    return this.http.post<Member>(
-      BASE_URL + 'access/state/init',
-      this.getMemberFromToken(),
-      {headers: this.authHeaderService.getAuthHeaders()}
+    return this.accessTokenService.createNewProfile(
+      this.getMemberFromToken()
     ).pipe(
       /* Tapping this here allows us to capture the newly created IDs from the backend. */
       tap(


### PR DESCRIPTION
…rst coming up

- Adds AccessTokenService with call to the `access/state` API endpoint.
- Refactors other calls to that endpoint into the service.
- Modifies the logic to only accept the back-end's idea of a valid token instead of
assuming what we've got is right.